### PR TITLE
fix: Docker multi-stage build + fix CI workflow

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,5 +1,4 @@
 name: Build and Push to GHCR & ACR
-# 此工作流仅在推送标签 (v*) 时触发，用于构建和推送 Docker 镜像
 
 on:
   push:
@@ -13,36 +12,14 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
-      # 设置 Docker Buildx（支持多架构构建）
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
-      # 设置 QEMU（用于模拟不同架构）
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
 
-      # 检查 ACR 是否启用
-      - name: Check if ACR registry is set
-        id: check-acr
-        run: |
-          if [ -n "${{ secrets.ACR_REGISTRY }}" ]; then
-            echo "acr_enabled=true" >> $GITHUB_OUTPUT
-          else
-            echo "acr_enabled=false" >> $GITHUB_OUTPUT
-          fi
-
-      # 登录 ACR（仅在启用时）
-      - name: Log in to Aliyun ACR
-        if: steps.check-acr.outputs.acr_enabled == 'true'
-        uses: docker/login-action@v3
-        with:
-          registry: ${{ secrets.ACR_REGISTRY }}
-          username: ${{ secrets.ACR_USERNAME }}
-          password: ${{ secrets.ACR_PASSWORD }}
-
-      # 登录 GitHub Container Registry
       - name: Log in to GitHub Container Registry
         uses: docker/login-action@v3
         with:
@@ -50,35 +27,35 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      # 获取仓库所有者小写形式
-      - name: Get lowercase repository owner
-        id: lowercase
-        run: echo "repository_owner_lowercase=$(echo '${{ github.repository_owner }}' | tr '[:upper:]' '[:lower:]')" >> $GITHUB_OUTPUT
+      - name: Log in to Aliyun ACR
+        if: ${{ secrets.ACR_REGISTRY != '' }}
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ secrets.ACR_REGISTRY }}
+          username: ${{ secrets.ACR_USERNAME }}
+          password: ${{ secrets.ACR_PASSWORD }}
 
-      # 准备镜像 tag（包括 latest 和版本 tag）
       - name: Prepare tags
         id: tags
         run: |
-          REPO_LOWERCASE="ghcr.io/${{ steps.lowercase.outputs.repository_owner_lowercase }}/open-web-search"
+          REPO_LOWERCASE="ghcr.io/$(echo '${{ github.repository_owner }}' | tr '[:upper:]' '[:lower:]')/agent-search-mcp"
           VERSION_TAG="${GITHUB_REF##*/}"
           TAGS="${REPO_LOWERCASE}:latest,${REPO_LOWERCASE}:${VERSION_TAG}"
 
-          if [ "${{ steps.check-acr.outputs.acr_enabled }}" == "true" ] && [ -n "${{ secrets.ACR_IMAGE_NAME }}" ]; then
+          if [ -n "${{ secrets.ACR_REGISTRY }}" ] && [ -n "${{ secrets.ACR_IMAGE_NAME }}" ]; then
             ACR_REPO="${{ secrets.ACR_REGISTRY }}/${{ secrets.ACR_IMAGE_NAME }}"
             TAGS="${TAGS},${ACR_REPO}:latest,${ACR_REPO}:${VERSION_TAG}"
           fi
 
-          # 输出 tags 结果
           echo "tags<<EOF" >> $GITHUB_OUTPUT
           echo "$TAGS" >> $GITHUB_OUTPUT
           echo "EOF" >> $GITHUB_OUTPUT
 
-      # 构建并推送多架构镜像
       - name: Build and Push Multi-Platform Docker Image
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v6
         with:
           context: .
-          platforms: linux/amd64,linux/arm64  # 🎯 这里添加了多平台支持
+          platforms: linux/amd64,linux/arm64
           push: true
           tags: ${{ steps.tags.outputs.tags }}
           cache-from: type=gha

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,18 @@
+# Stage 1: Build
+FROM node:20-alpine AS builder
+WORKDIR /app
+COPY package*.json ./
+RUN npm ci
+COPY tsconfig.json ./
+COPY src/ ./src/
+RUN npm run build
+
+# Stage 2: Production
+FROM node:20-alpine
+WORKDIR /app
+COPY package*.json ./
+RUN npm ci --only=production && npm cache clean --force
+COPY --from=builder /app/dist ./dist
+COPY README.md README_zh.md LICENSE CHANGELOG.md ./
+EXPOSE 3000
+CMD ["node", "dist/index.js"]


### PR DESCRIPTION
## 问题

GitHub Actions workflow "Build and Push to GHCR & ACR" 在 `v2.1.0` tag 构建失败（15秒）。

## 根因

1. `dist/` 在 `.gitignore` 中，未被 git 跟踪
2. Workflow 没有 `npm run build` 步骤
3. Dockerfile `COPY dist/ ./dist/` 找不到目录 → 构建失败
4. Workflow 中镜像名写死 `open-web-search`，实际应该是 `agent-search-mcp`

## 改动

| 文件 | 改动 |
|------|------|
| `Dockerfile` | 单阶段 → 多阶段构建，Node 18 → 20，编译在 Docker 内完成 |
| `docker.yml` | 镜像名 `open-web-search` → `agent-search-mcp`，简化 ACR 登录，actions 版本更新 |

## 验证

- [x] Dockerfile 多阶段构建语法正确
- [x] docker.yml YAML 语法验证通过
- [x] 所有引用文件存在（tsconfig.json, src/, package-lock.json）
- [ ] CI 构建需触发验证（打 v* tag 后自动执行）
