### PR TITLE
docs: add mcp-slim-guard companion section

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,15 @@
+root = true
+
+[*]
+indent_style = space
+indent_size = 2
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+[*.md]
+trim_trailing_whitespace = false
+
+[*.{yml,yaml}]
+indent_size = 2

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,14 @@
+version: 2
+updates:
+  - package-ecosystem: npm
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+    open-pull-requests-limit: 5
+    labels:
+      - dependencies
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: monthly

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,3 +70,10 @@ jobs:
         run: npm publish
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      - name: Create GitHub Release
+        if: steps.check.outputs.already_published == 'false'
+        uses: softprops/action-gh-release@v2
+        with:
+          body_path: CHANGELOG.md
+          generate_release_notes: true

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,9 +7,11 @@ RUN npm run build
 
 FROM node:20-slim AS runtime
 WORKDIR /app
+RUN groupadd -r agent-search && useradd -r -g agent-search agent-search
 COPY --from=build /app/dist ./dist
 COPY --from=build /app/node_modules ./node_modules
 COPY --from=build /app/package*.json ./
+USER agent-search
 EXPOSE 3000
 ENV MODE=http
 ENV PORT=3000

--- a/README.md
+++ b/README.md
@@ -341,6 +341,33 @@ npm run dev:http  # HTTP mode (port 3000)
 
 ---
 
+## 🔗 Companion Tools
+
+**🛡️ [mcp-slim-guard](https://github.com/lennney/mcp-slim-guard)** — Add security + compression to your MCP stack
+
+```bash
+npm install -g mcp-slim-guard
+mcp-slim-guard init
+mcp-slim-guard start
+```
+
+Pair agent-search-mcp with mcp-slim-guard to get:
+
+| Feature | Benefit |
+|---------|---------|
+| **Schema compression** | Reclaim ~83% of context window — 1,736 → 300 tokens |
+| **Tool allow/deny** | Glob-based whitelist/blacklist for tool access control |
+| **SSRF protection** | IP blacklist + domain whitelist blocks internal network requests |
+| **Injection detection** | 17 heuristic patterns prevent prompt/shell/SQL injection |
+| **Rate limiting** | Token bucket per-tool, default 60 req/min |
+| **Audit logging** | Structured JSON audit log with rotation + gzip |
+
+```
+AI Agent → mcp-slim-guard (security + compression) → agent-search-mcp
+```
+
+---
+
 ## License
 
 [MIT](LICENSE)

--- a/README_zh.md
+++ b/README_zh.md
@@ -520,6 +520,33 @@ Copyright 2026 Agent Search MCP Contributors
 
 ---
 
+## 🔗 推荐搭配
+
+**🛡️ [mcp-slim-guard](https://github.com/lennney/mcp-slim-guard)** — 给你的 MCP 栈添加安全 + 压缩
+
+```bash
+npm install -g mcp-slim-guard
+mcp-slim-guard init
+mcp-slim-guard start
+```
+
+agent-search-mcp + mcp-slim-guard = 搜索 + 安全 + Token 节省三合一：
+
+| 功能 | 效果 |
+|------|------|
+| **Schema 压缩** | 节省 ~83% 上下文窗口 — 1,736 → 300 tokens |
+| **工具白名单** | Glob 模式控制哪些工具可调用 |
+| **SSRF 保护** | IP 黑名单 + 域名白名单，阻止内网请求 |
+| **注入检测** | 17 种启发式模式，防提示注入/SQL/Shell |
+| **速率限制** | 每工具 Token Bucket，默认 60 req/min |
+| **审计日志** | 结构化 JSON 日志，支持轮转 + gzip |
+
+```
+AI Agent → mcp-slim-guard (安全 + 压缩) → agent-search-mcp
+```
+
+---
+
 ## Contributing
 
 欢迎贡献！请先阅读 [CONTRIBUTING.md](CONTRIBUTING.md)。

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agent-search-mcp",
-  "version": "3.1.0",
+  "version": "3.1.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agent-search-mcp",
-      "version": "3.1.0",
+      "version": "3.1.2",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",
@@ -2419,9 +2419,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
-      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.4.tgz",
+      "integrity": "sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==",
       "funding": [
         {
           "type": "github",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,6 @@
 {
   "name": "agent-search-mcp",
+  "mcpName": "io.github.lennney/agent-search-mcp",
   "version": "3.1.2",
   "description": "Zero-config, 11-engine free MCP search server for AI agents. DuckDuckGo, Sogou, Bing, Baidu + 7 more. No API keys needed. Waterfall progressive search, multi-source verification, content extraction, news & CLI.",
   "type": "module",

--- a/server.json
+++ b/server.json
@@ -1,0 +1,57 @@
+{
+  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+  "name": "io.github.lennney/agent-search-mcp",
+  "description": "11-engine MCP search server for AI agents. Free, zero API keys needed. Waterfall, verify, extract.",
+  "repository": {
+    "url": "https://github.com/lennney/agent-search-mcp",
+    "source": "github"
+  },
+  "version": "3.1.2",
+  "packages": [
+    {
+      "registryType": "npm",
+      "identifier": "agent-search-mcp",
+      "version": "3.1.2",
+      "transport": {
+        "type": "stdio"
+      },
+      "environmentVariables": [
+        {
+          "description": "Brave Search API key (optional, enables Brave engine)",
+          "isRequired": false,
+          "format": "string",
+          "isSecret": true,
+          "name": "BRAVE_API_KEY"
+        },
+        {
+          "description": "Tavily Search API key (optional, enables Tavily engine)",
+          "isRequired": false,
+          "format": "string",
+          "isSecret": true,
+          "name": "TAVILY_API_KEY"
+        },
+        {
+          "description": "Exa Search API key (optional, enables Exa engine)",
+          "isRequired": false,
+          "format": "string",
+          "isSecret": true,
+          "name": "EXA_API_KEY"
+        },
+        {
+          "description": "Run mode: stdio (default), http, or both",
+          "isRequired": false,
+          "format": "string",
+          "isSecret": false,
+          "name": "MODE"
+        },
+        {
+          "description": "HTTP port (default: 3000)",
+          "isRequired": false,
+          "format": "number",
+          "isSecret": false,
+          "name": "PORT"
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
Adds a recommended companion section for mcp-slim-guard — the security + compression proxy for MCP stacks.

Links: https://github.com/lennney/mcp-slim-guard
npm: `mcp-slim-guard`