### PR TITLE
feat: add optional You.com search engine

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Agent Search MCP
 
-> 🔍 **11 search engines (8 free), one MCP server.** Zero API keys. Chinese search. Multi-source verification. Waterfall progressive search, content extraction, news & CLI. `npm install` is enough.
+> 🔍 **12 search engines (8 free), one MCP server.** Zero API keys. Chinese search. Multi-source verification. Waterfall progressive search, content extraction, news & CLI. `npm install` is enough.
 
 [![npm version](https://img.shields.io/npm/v/agent-search-mcp)](https://www.npmjs.com/package/agent-search-mcp)
 [![npm downloads](https://img.shields.io/npm/dm/agent-search-mcp)](https://www.npmjs.com/package/agent-search-mcp)
@@ -230,6 +230,7 @@ Stops as soon as results are sufficient. Saves 50-75% engine calls.
 | `BRAVE_API_KEY` | — | Brave Search API key (2K free/month) |
 | `TAVILY_API_KEY` | — | Tavily API key (1K free/month) |
 | `EXA_API_KEY` | — | Exa API key (1K free/month) |
+| `YDC_API_KEY` | — | You.com API key (optional; improves authenticated access beyond the free tier) |
 | `LOG_LEVEL` | `info` | Log level: `info`, `debug` |
 | `MODE` | `stdio` | Transport: `stdio`, `http`, `both` |
 | `PORT` | `3000` | HTTP server port (MODE=http/both) |
@@ -275,7 +276,7 @@ DENIED_ENGINES=yandex,mojeek
 ```bash
 # Search
 fasm search "TypeScript MCP server"
-fasm search "query" --count 5 --engines bing,baidu --json
+fasm search "query" --count 5 --engines bing,baidu,youcom --json
 
 # Extract
 fasm extract "https://example.com"
@@ -304,9 +305,9 @@ MCP Server
   │   ├── Dedup (URL + title)
   │   ├── Content Enrichment (Jina Reader)
   │   └── Query Expansion (rule-based, 4 strategies)
-  ├── Engine Layer (11 engines)
+  ├── Engine Layer (12 engines)
   │   ├── Free: DDG, Sogou, Bing, Baidu, Wikipedia, Startpage, Yandex, Mojeek
-  │   └── Paid: Brave, Tavily, Exa
+  │   └── Paid/optional: Brave, Tavily, Exa, You.com
   └── Infrastructure
       ├── Health Tracker (per-engine circuit breaking)
       ├── Rate Limiter (adaptive concurrency)
@@ -336,7 +337,7 @@ npm run dev:http  # HTTP mode (port 3000)
 | Metric | Value |
 |--------|-------|
 | Tests | 448 passing, 40 files |
-| Engines | 11 (8 free, 3 paid) |
+| Engines | 12 (8 free, 4 paid/optional) |
 | MCP Tools | 8 |
 | Dependencies | 5 production |
 | Node.js | >= 18 |

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -26,7 +26,7 @@ export interface CliArgs {
 }
 
 const VALID_COMMANDS = ['search', 'extract', 'serve'];
-const VALID_ENGINES: SearchProvider[] = ['duckduckgo', 'sogou', 'bing', 'baidu', 'brave', 'tavily', 'exa'];
+const VALID_ENGINES: SearchProvider[] = ['duckduckgo', 'sogou', 'bing', 'baidu', 'brave', 'tavily', 'exa', 'youcom'];
 
 export function parseArgs(argv: string[]): CliArgs {
   const args = argv.slice(2); // skip node and script path
@@ -98,7 +98,7 @@ Usage:
 
 Search Options:
   --count <n>          Number of results (1-50, default: 10)
-  --engines <list>     Comma-separated engines (duckduckgo,sogou,bing,baidu,brave,tavily,exa)
+  --engines <list>     Comma-separated engines (duckduckgo,sogou,bing,baidu,brave,tavily,exa,youcom)
   --json               Output as JSON
   --proxy <url>        HTTP proxy URL (e.g., http://127.0.0.1:7890)
 
@@ -111,7 +111,7 @@ Serve Options:
 
 Examples:
   fasm search "TypeScript MCP server"
-  fasm search "query" --count 5 --engines bing,baidu
+  fasm search "query" --count 5 --engines bing,baidu,youcom
   fasm extract "https://example.com" --json
   fasm serve --port 8080
   fasm search "query" --proxy http://127.0.0.1:7890

--- a/src/engines/index.ts
+++ b/src/engines/index.ts
@@ -11,11 +11,12 @@ export { searchWikipedia, wikipediaProvider } from './wikipedia.js';
 export { searchStartpage, startpageProvider } from './startpage.js';
 export { searchYandex, yandexProvider } from './yandex.js';
 export { searchMojeek, mojeekProvider } from './mojeek.js';
+export { searchYouCom, youcomProvider } from './youcom.js';
 
 /**
  * All registered engine providers with metadata.
  * Free engines: DDG, Sogou, Bing, Baidu
- * Paid engines: Brave, Tavily, Exa (require API keys)
+ * Paid engines: Brave, Tavily, Exa, You.com (require or optionally use API keys)
  */
 export const engines: Record<SearchProvider, SearchProviderInfo> = {
   duckduckgo: { id: 'duckduckgo', name: 'DuckDuckGo', isFree: true, languages: ['en'] },
@@ -29,10 +30,11 @@ export const engines: Record<SearchProvider, SearchProviderInfo> = {
   brave: { id: 'brave', name: 'Brave Search', isFree: false, languages: ['en', 'zh'] },
   tavily: { id: 'tavily', name: 'Tavily Search', isFree: false, languages: ['en', 'zh'] },
   exa: { id: 'exa', name: 'Exa Search', isFree: false, languages: ['en', 'zh'] },
+  youcom: { id: 'youcom', name: 'You.com Search', isFree: false, languages: ['en', 'zh'] },
 };
 
 /** Free engines that always work without API keys */
 export const freeEngines: SearchProvider[] = ['duckduckgo', 'sogou', 'bing', 'baidu', 'wikipedia', 'startpage', 'yandex', 'mojeek'];
 
 /** Paid engines that require API keys */
-export const paidEngines: SearchProvider[] = ['brave', 'tavily', 'exa'];
+export const paidEngines: SearchProvider[] = ['brave', 'tavily', 'exa', 'youcom'];

--- a/src/engines/youcom.ts
+++ b/src/engines/youcom.ts
@@ -1,0 +1,67 @@
+import { SearchResult } from '../types.js';
+
+export const youcomProvider = {
+  id: 'youcom' as const,
+  name: 'You.com Search',
+  isFree: false,
+  languages: ['en', 'zh'],
+};
+
+interface YouComSearchItem {
+  url?: string;
+  title?: string;
+  description?: string;
+  snippets?: string[];
+}
+
+interface YouComSearchResponse {
+  results?: {
+    web?: YouComSearchItem[];
+    news?: YouComSearchItem[];
+  };
+}
+
+function mapResult(result: YouComSearchItem): SearchResult | null {
+  const title = result.title?.trim() || '';
+  const url = result.url?.trim() || '';
+  if (!title || !url) return null;
+
+  return {
+    title,
+    url,
+    snippet: result.description?.trim() || result.snippets?.[0]?.trim() || '',
+    source: 'youcom',
+    engines: ['youcom'],
+  };
+}
+
+export async function searchYouCom(query: string, count: number = 10): Promise<SearchResult[]> {
+  const url = new URL('https://api.you.com/v1/agents/search');
+  url.searchParams.set('query', query);
+  url.searchParams.set('count', String(count));
+
+  const headers: Record<string, string> = {
+    Accept: 'application/json',
+  };
+
+  const apiKey = process.env.YDC_API_KEY;
+  if (apiKey) {
+    headers['X-API-Key'] = apiKey;
+  }
+
+  const res = await fetch(url.toString(), {
+    headers,
+    signal: AbortSignal.timeout(10000),
+  });
+
+  if (!res.ok) {
+    throw new Error(`You.com HTTP ${res.status}`);
+  }
+
+  const data = (await res.json()) as YouComSearchResponse;
+  const combined = [...(data.results?.web || []), ...(data.results?.news || [])];
+  return combined
+    .map(mapResult)
+    .filter((result): result is SearchResult => result !== null)
+    .slice(0, count);
+}

--- a/src/infrastructure/rate-limiter.ts
+++ b/src/infrastructure/rate-limiter.ts
@@ -15,7 +15,7 @@ export interface RateLimiterOptions {
  * Per-engine rate limiter for lightweight VPS.
  *
  * Free engines (DDG, Sogou, Baidu) need longer intervals to avoid anti-bot;
- * paid engines (Brave, Tavily, Exa) can be called more aggressively.
+ * paid engines (Brave, Tavily, Exa, You.com) can be called more aggressively.
  *
  * All state is in-memory — no persistence, no background sweeps.
  */
@@ -24,7 +24,7 @@ export class RateLimiter {
   private engineRates: Record<string, number>;
   private defaultIntervalMs: number;
 
-  // Sensible defaults for 11 engines on a lightweight VPS
+  // Sensible defaults for 12 engines on a lightweight VPS
   static readonly DEFAULT_ENGINE_RATES: Record<string, number> = {
     // Free engines — respectful intervals to avoid rate-limiting
     ddg: 1_200,
@@ -37,6 +37,7 @@ export class RateLimiter {
     brave: 400,
     tavily: 300,
     exa: 300,
+    youcom: 500,
     yandex: 600,
     mojeek: 600,
   };

--- a/src/tools/free-search.ts
+++ b/src/tools/free-search.ts
@@ -7,13 +7,14 @@ import { searchBaidu } from '../engines/baidu.js';
 import { BraveProvider } from '../engines/brave.js';
 import { TavilyProvider } from '../engines/tavily.js';
 import { searchExa } from '../engines/exa.js';
+import { searchYouCom } from '../engines/youcom.js';
 import type { SearchResult, SearchProvider, EngineError } from '../types.js';
 import { dedupByUrl, dedupByTitle, filterLowQuality, scoreAndRank, formatResults, checkConfidenceBasket, enrichResults, expandQuery, hasChinese, generateChineseVariants, detectLanguage } from '../aggregation/index.js';
 import { SearchCache, logger, HealthTracker, RateLimiter, loadConfig, EnginePolicy, ServerMetrics } from '../infrastructure/index.js';
 
-const ALL_ENGINES: SearchProvider[] = ['duckduckgo', 'sogou', 'bing', 'baidu', 'brave', 'tavily', 'exa'];
+const ALL_ENGINES: SearchProvider[] = ['duckduckgo', 'sogou', 'bing', 'baidu', 'brave', 'tavily', 'exa', 'youcom'];
 const FREE_ENGINES: SearchProvider[] = ['duckduckgo', 'sogou', 'bing', 'baidu'];
-const PAID_ENGINES: SearchProvider[] = ['brave', 'tavily', 'exa'];
+const PAID_ENGINES: SearchProvider[] = ['brave', 'tavily', 'exa', 'youcom'];
 
 // Engine weights (higher = more trusted)
 const ENGINE_WEIGHTS: Record<string, number> = {
@@ -24,6 +25,7 @@ const ENGINE_WEIGHTS: Record<string, number> = {
   brave: 0.95,
   tavily: 0.9,
   exa: 0.92,
+  youcom: 0.91,
 };
 
 // Infrastructure singletons
@@ -44,6 +46,7 @@ const PROVIDER_MAP: Record<string, string> = {
   brave: 'brave',
   tavily: 'tavily',
   exa: 'exa',
+  youcom: 'youcom',
 };
 
 /**
@@ -122,6 +125,9 @@ async function searchEngine(
           break;
         case 'exa':
           results = await searchExa({ query, count: limit, apiKey: process.env.EXA_API_KEY || '' });
+          break;
+        case 'youcom':
+          results = await searchYouCom(query, limit);
           break;
         default:
           return [];
@@ -216,6 +222,8 @@ function hasApiKey(engine: SearchProvider): boolean {
       return !!process.env.TAVILY_API_KEY;
     case 'exa':
       return !!process.env.EXA_API_KEY;
+    case 'youcom':
+      return true;
     default:
       return true; // free engines always available
   }
@@ -787,11 +795,11 @@ export function setupFreeSearchTool(server: McpServer): void {
         query: z.string().min(1, 'Search query must not be empty')
           .describe('Search query string. Use natural language (e.g., "latest AI news 2026"). For Chinese queries, Sogou and Baidu are used automatically.'),
         limit: z.number().int().min(1).max(50).default(10).describe('Number of results to return (1-50). Default 10. Higher values increase token usage.'),
-        engines: z.array(z.enum(['duckduckgo', 'sogou', 'bing', 'baidu', 'brave', 'tavily', 'exa']))
+        engines: z.array(z.enum(['duckduckgo', 'sogou', 'bing', 'baidu', 'brave', 'tavily', 'exa', 'youcom']))
           .min(1)
           .default(['duckduckgo', 'sogou'])
           .describe('Search engines to use (default: duckduckgo + sogou). Free engines work without API keys. ' +
-            'Paid engines (brave/tavily/exa) require corresponding env vars. ' +
+            'Paid engines (brave/tavily/exa) require corresponding env vars. You.com works without a key and can use YDC_API_KEY for authenticated access. ' +
             'For Chinese results, include sogou or baidu.'),
       },
       annotations: { readOnlyHint: true, idempotentHint: true },

--- a/src/types.ts
+++ b/src/types.ts
@@ -6,7 +6,7 @@ export interface SearchResult {
   engines?: string[];  // populated by aggregation layer, or set by single-engine searches
 }
 
-export type SearchProvider = 'duckduckgo' | 'sogou' | 'brave' | 'tavily' | 'bing' | 'baidu' | 'exa' | 'wikipedia' | 'startpage' | 'yandex' | 'mojeek';
+export type SearchProvider = 'duckduckgo' | 'sogou' | 'brave' | 'tavily' | 'bing' | 'baidu' | 'exa' | 'wikipedia' | 'startpage' | 'yandex' | 'mojeek' | 'youcom';
 
 export interface SearchProviderInfo {
   id: SearchProvider;

--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -9,11 +9,11 @@ describe('parseArgs', () => {
   });
 
   it('parses search with options', () => {
-    const args = parseArgs(['node', 'cli.ts', 'search', 'query', '--count', '5', '--engines', 'bing,baidu']);
+    const args = parseArgs(['node', 'cli.ts', 'search', 'query', '--count', '5', '--engines', 'bing,baidu,youcom']);
     expect(args.command).toBe('search');
     expect(args.query).toBe('query');
     expect(args.count).toBe(5);
-    expect(args.engines).toEqual(['bing', 'baidu']);
+    expect(args.engines).toEqual(['bing', 'baidu', 'youcom']);
   });
 
   it('parses extract command', () => {
@@ -50,8 +50,8 @@ describe('parseArgs', () => {
   });
 
   it('filters invalid engines', () => {
-    const args = parseArgs(['node', 'cli.ts', 'search', 'query', '--engines', 'bing,invalid,baidu']);
-    expect(args.engines).toEqual(['bing', 'baidu']);
+    const args = parseArgs(['node', 'cli.ts', 'search', 'query', '--engines', 'bing,invalid,baidu,youcom']);
+    expect(args.engines).toEqual(['bing', 'baidu', 'youcom']);
   });
 
   it('parses --proxy flag', () => {

--- a/tests/engines/youcom.test.ts
+++ b/tests/engines/youcom.test.ts
@@ -1,0 +1,90 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { searchYouCom, youcomProvider } from '../../src/engines/youcom.js';
+
+describe('You.com engine', () => {
+  const mockFetch = vi.fn();
+
+  beforeEach(() => {
+    vi.stubGlobal('fetch', mockFetch);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+    delete process.env.YDC_API_KEY;
+  });
+
+  it('has correct provider metadata', () => {
+    expect(youcomProvider.id).toBe('youcom');
+    expect(youcomProvider.name).toBe('You.com Search');
+    expect(youcomProvider.isFree).toBe(false);
+    expect(youcomProvider.languages).toContain('en');
+  });
+
+  it('searchYouCom returns mapped web and news results without an API key', async () => {
+    mockFetch.mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        results: {
+          web: [
+            {
+              title: 'Web Result',
+              url: 'https://example.com/web',
+              description: 'Web snippet',
+            },
+          ],
+          news: [
+            {
+              title: 'News Result',
+              url: 'https://example.com/news',
+              snippets: ['News snippet'],
+            },
+          ],
+        },
+      }),
+    });
+
+    const results = await searchYouCom('test query', 5);
+
+    expect(results).toHaveLength(2);
+    expect(results[0]).toMatchObject({
+      title: 'Web Result',
+      url: 'https://example.com/web',
+      snippet: 'Web snippet',
+      source: 'youcom',
+    });
+    expect(results[1]).toMatchObject({
+      title: 'News Result',
+      url: 'https://example.com/news',
+      snippet: 'News snippet',
+      source: 'youcom',
+    });
+    expect(results[0].engines).toEqual(['youcom']);
+  });
+
+  it('searchYouCom sends YDC_API_KEY when configured', async () => {
+    process.env.YDC_API_KEY = 'test-key';
+    mockFetch.mockResolvedValue({
+      ok: true,
+      json: async () => ({ results: { web: [] } }),
+    });
+
+    await searchYouCom('test query', 5);
+
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+    const [, init] = mockFetch.mock.calls[0];
+    expect(init?.headers).toMatchObject({
+      Accept: 'application/json',
+      'X-API-Key': 'test-key',
+    });
+  });
+
+  it('searchYouCom throws on HTTP error', async () => {
+    mockFetch.mockResolvedValue({
+      ok: false,
+      status: 500,
+    });
+
+    await expect(searchYouCom('test query', 5)).rejects.toThrow('You.com HTTP 500');
+  });
+});

--- a/tests/infrastructure/tool-policy.test.ts
+++ b/tests/infrastructure/tool-policy.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect } from 'vitest';
 import { EnginePolicy, ToolPolicy } from '../../src/infrastructure/tool-policy.js';
 import type { SearchProvider } from '../../src/types.js';
 
-const ALL_ENGINES: SearchProvider[] = ['duckduckgo', 'sogou', 'bing', 'baidu', 'brave', 'tavily', 'exa'];
+const ALL_ENGINES: SearchProvider[] = ['duckduckgo', 'sogou', 'bing', 'baidu', 'brave', 'tavily', 'exa', 'youcom'];
 
 describe('EnginePolicy', () => {
   describe('empty/null config', () => {
@@ -84,7 +84,7 @@ describe('EnginePolicy', () => {
     });
 
     it('returns empty array when nothing is allowed', () => {
-      const policy = new EnginePolicy('', 'duckduckgo,sogou,bing,baidu,brave,tavily,exa');
+      const policy = new EnginePolicy('', 'duckduckgo,sogou,bing,baidu,brave,tavily,exa,youcom');
       const result = policy.filterEngines(ALL_ENGINES);
       expect(result).toEqual([]);
     });


### PR DESCRIPTION
## Problem
This project already has a solid multi-engine search path. You.com fits as another optional provider for agents that want a different web index without changing the default behavior for everyone else.

## Solution
- Added a new `youcom` search engine backed by `https://api.you.com/v1/agents/search`
- Wired it into the engine registry, CLI engine validation, and the `free_search` tool selection path
- Kept it opt-in through the existing `--engines` / MCP engine list
- Added tests for the provider mapping and the updated engine lists

## Setup
- `YDC_API_KEY` is optional
- When set, it is sent as `X-API-Key`
- No existing defaults change if users never select `youcom`

## Usage
```bash
fasm search "mcp server search" --engines bing,youcom
```

## Validation
- `npm run build`
- `npm test`
- `npm run lint` could not be completed here because the repo’s current TypeScript 7 / `typescript-eslint` combo is incompatible in this checkout

## Fallback / error handling
- Missing `YDC_API_KEY` does not block the engine
- Non-2xx responses raise a clear You.com HTTP error so the search wrapper can classify it normally
- The engine is only used when explicitly selected, so existing defaults are unchanged

Tracking issue: https://github.com/youdotcom-oss/integration-tracking/issues/116
