### PR TITLE
docs: unify README messaging, add benchmark data, fix inconsistencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,77 +1,77 @@
----
-type: Readme
-title: Agent Search MCP — 11 引擎统一搜索 MCP Server
-timestamp: '2026-07-24T09:30:00+08:00'
-description: 11 搜索引擎（8 免费），MCP 协议接入，零 API key，中文搜索，多源验证
-tags:
-- agent-search-mcp
-- readme
-- mcp
-- search
----
-
 # Agent Search MCP
 
-> 🔍 **12 search engines (8 free), one MCP server.** Zero API keys. Chinese search. Multi-source verification. Waterfall progressive search, content extraction, news & CLI. `npm install` is enough.
+> **12 search engines (8 free, zero API keys), one MCP server.**
+> Chinese search via Sogou + Baidu. Multi-source verification with confidence scoring. Waterfall progressive search. Content extraction. `npx agent-search-mcp` is all you need.
 
 [![npm version](https://img.shields.io/npm/v/agent-search-mcp)](https://www.npmjs.com/package/agent-search-mcp)
 [![npm downloads](https://img.shields.io/npm/dm/agent-search-mcp)](https://www.npmjs.com/package/agent-search-mcp)
 [![GitHub stars](https://img.shields.io/github/stars/lennney/agent-search-mcp)](https://github.com/lennney/agent-search-mcp/stargazers)
 [![CI](https://github.com/lennney/agent-search-mcp/actions/workflows/ci.yml/badge.svg)](https://github.com/lennney/agent-search-mcp/actions)
-[![License](https://img.shields.io/github/license/lennney/agent-search-mcp)](LICENSE)
-[![Node.js](https://img.shields.io/badge/node-%3E%3D18-brightgreen)](package.json)
-[![Tests](https://img.shields.io/badge/tests-463%20passing-brightgreen)](https://github.com/lennney/agent-search-mcp)
-|![Glama](https://glama.ai/mcp/servers/lennney/agent-search-mcp/badges/score.svg)](https://glama.ai/mcp/servers/lennney/agent-search-mcp)
+[![License](https://img.shields.io/badge/license-Apache%202.0-blue)](LICENSE)
+[![Glama](https://glama.ai/mcp/servers/lennney/agent-search-mcp/badges/score.svg)](https://glama.ai/mcp/servers/lennney/agent-search-mcp)
 
-**Works with Claude Code, Claude Desktop, Cursor, Windsurf, VS Code, Codex, Hermes, and any MCP-compatible client.**
+[中文文档](README_zh.md) · [Benchmarks](./benchmarks/) · [CHANGELOG](./CHANGELOG.md)
 
-> ⭐ **[Star on GitHub](https://github.com/lennney/agent-search-mcp)** — it helps others discover the project!
+---
 
-## Project Snapshot
+## Why Agent Search MCP
 
-| | |
-|---|---|
-| **Engines** | 11 (8 free, no API key) |
-| **MCP Tools** | 8 (search, news, extract, fetch) |
-| **Transports** | stdio + Streamable HTTP |
-| **Latest version** | [v3.1.3](https://www.npmjs.com/package/agent-search-mcp) |
-| **Tests** | 463 passing |
-| **Install** | `npx agent-search-mcp` |
-| **MCP Registry** | `io.github.lennney/agent-search-mcp` |
+Most MCP search servers wrap a single paid API — one engine, one bill. Agent Search MCP is built differently.
 
-[Benchmarks →](./benchmarks/) — 100% success rate across 30 queries, 100% waterfall efficiency.
+| | Agent Search MCP | Tavily | Exa | Brave |
+|---|:---:|:---:|:---:|:---:|
+| **Price** | **$0** | ~$30/mo | $50/mo | ~$15/mo |
+| **Free engines** | **8** | 0 | 0 | 1 (2K/mo cap) |
+| **API key required** | No | Yes | Yes | Yes |
+| **Multi-source verify** | ✅ 8 engines | ❌ | ❌ | ❌ |
+| **Chinese search** | ✅ Sogou+Baidu | ❌ | ❌ | ❌ |
+| **Self-hosted** | ✅ | ❌ | ❌ | ❌ |
 
-[English](#quick-start) · [中文](README_zh.md) · [Tools](#tools) · [CLI](#cli) · [Engines](#engines) · [Config](#configuration)
+### Free, forever
+
+8 engines work with zero configuration — DuckDuckGo, Sogou, Bing, Baidu, Wikipedia, Startpage, Yandex, Mojeek. No API keys, no signup, no credit card. At 100 searches/day, that saves $30–50/month vs paid alternatives.
+
+### 75% fewer engine calls
+
+Benchmarked on [30 diverse queries](./benchmarks/) (15 English + 15 Chinese): **100% satisfied at waterfall phase 1** with just 2 engines. A naive multi-search would call all 8 every time. The waterfall stops early when confidence is sufficient — fewer calls, less latency, less data fed to the LLM.
+
+### Multi-source verification
+
+DDG and Sogou return **zero-overlap result sets** — you get genuinely broader coverage than any single engine can provide. Each result is scored 1–3 based on how many sources agree. Confidence-2+ results have been cross-checked by multiple engines.
+
+### Token-efficient architecture
+
+Two layers of savings, benchmarked on 30 EN+ZH queries:
+- **Waterfall stops early** → 2 engines instead of 8 → **75% fewer engine calls**
+- **Compact mode** → strips metadata noise + progressive disclosure → **28.7% fewer tokens** (1582 → 1128)
+- **Compact Aggressive** (`SNIPPET_LENGTH=120`) → **35.5% fewer tokens** (1582 → 1020)
+
+### Native Chinese search
+
+Sogou + Baidu search the Chinese web directly — WeChat content, Baidu Baike, Chinese forums. Not a translation layer, not an afterthought.
 
 ---
 
 ## Quick Start
 
-### Prerequisites
-
-- **Node.js >= 18** — that's it. No Python, no API keys, no Docker required.
-
-### Install
-
 ```bash
-# npx (no install)
+# One command — no install, no API keys
 npx agent-search-mcp
-
-# Global install
-npm install -g agent-search-mcp
 ```
 
-### Configure Your Client
+Requires Node.js >= 18.
+
+### Client Configuration
 
 <details>
-<summary><b>Claude Code</b></summary>
+<summary><b>Claude Code / Claude Desktop</b></summary>
 
 ```json
 {
   "mcpServers": {
     "agent-search": {
       "command": "npx",
-      "args": ["agent-search-mcp"]
+      "args": ["-y", "agent-search-mcp"]
     }
   }
 }
@@ -79,44 +79,14 @@ npm install -g agent-search-mcp
 </details>
 
 <details>
-<summary><b>Claude Desktop</b></summary>
+<summary><b>Cursor / VS Code / Codex</b></summary>
 
 ```json
 {
   "mcpServers": {
     "agent-search": {
       "command": "npx",
-      "args": ["agent-search-mcp"]
-    }
-  }
-}
-```
-</details>
-
-<details>
-<summary><b>Cursor</b></summary>
-
-```json
-{
-  "mcpServers": {
-    "agent-search": {
-      "command": "npx",
-      "args": ["agent-search-mcp"]
-    }
-  }
-}
-```
-</details>
-
-<details>
-<summary><b>VS Code / Cline / Roo Code</b></summary>
-
-```json
-{
-  "mcpServers": {
-    "agent-search": {
-      "command": "npx",
-      "args": ["agent-search-mcp"]
+      "args": ["-y", "agent-search-mcp"]
     }
   }
 }
@@ -131,7 +101,7 @@ npm install -g agent-search-mcp
   "mcpServers": {
     "agent-search": {
       "command": "npx",
-      "args": ["agent-search-mcp"]
+      "args": ["-y", "agent-search-mcp"]
     }
   }
 }
@@ -145,52 +115,9 @@ npm install -g agent-search-mcp
 mcp_servers:
   agent-search:
     command: npx
-    args: ["agent-search-mcp"]
+    args: ["-y", "agent-search-mcp"]
 ```
 </details>
-
-<details>
-<summary><b>Codex</b></summary>
-
-```json
-{
-  "mcpServers": {
-    "agent-search": {
-      "command": "npx",
-      "args": ["agent-search-mcp"]
-    }
-  }
-}
-```
-</details>
-
----
-
-## Why Agent Search MCP
-
-**AI agents need to search the web. But existing options have problems:**
-
-| Solution | Price | The Catch |
-|----------|-------|------------|
-| Tavily | $0.01/search | Monthly cost: $20-50+ |
-| Exa | $50/mo | Powerful semantic search, but expensive |
-| Brave Search | $3/1K after 2K free | Free quota runs out fast |
-| DDG MCP | Free | Single source, no verification, results vary |
-| Serper | $0.30/1K | Google SERP, no content extraction |
-
-**Agent Search MCP is different:**
-
-| Capability | Why It Matters |
-|------------|----------------|
-| **8 free engines, zero API keys** | DuckDuckGo, Sogou, Bing, Baidu, Wikipedia, Startpage, Yandex, Mojeek — all work out of the box |
-| **Waterfall progressive search** | Runs engines in confidence-gated phases. Stops early when results are sufficient — saves 50-75% calls |
-| **Multi-source verification** | Cross-checks results across engines. Each result scored 1-3 based on how many sources agree |
-| **Chinese search** | Sogou + Baidu for native Chinese web search. Not a translation layer |
-| **Content enrichment** | Auto-extracts full page content for low-confidence results via Jina Reader |
-| **MCP 2025 compliant** | Streamable HTTP transport, `readOnlyHint`/`idempotentHint` annotations, explicit capabilities |
-| **Token optimized** | Smart truncation + dedup saves ~40-50% tokens vs raw search |
-| **Self-hostable** | No third-party data sharing. Run on your own VPS |
-| **Security built-in** | SSRF protection, prompt injection detection, URL validation |
 
 ---
 
@@ -198,17 +125,18 @@ mcp_servers:
 
 | Engine | Free | Strengths |
 |--------|:----:|-----------|
-| **DuckDuckGo** | ✅ | Privacy-focused, English web. Python ddgs preferred, cheerio HTML fallback |
+| **DuckDuckGo** | ✅ | Privacy-focused, English web |
 | **Sogou** | ✅ | Chinese web search, WeChat content |
 | **Bing** | ✅ | Multilingual, strong English results |
 | **Baidu** | ✅ | Chinese web search, Baidu Baike |
 | **Wikipedia** | ✅ | Clean JSON API, structured knowledge |
 | **Startpage** | ✅ | Google results via privacy proxy |
-| **Yandex** | ✅ | Russian web search |
+| **Yandex** | ✅ | Russian/Cyrillic web search |
 | **Mojeek** | ✅ | Independent crawler, privacy-focused |
-| Brave Search | ❌ | High-quality web results, 2K free/month |
-| Tavily | ❌ | Agent-optimized search, 1K free/month |
-| Exa | ❌ | Neural semantic search, 1K free/month |
+| Brave Search | ❌ | High-quality web results (2K free/month) |
+| Tavily | ❌ | Agent-optimized search (1K free/month) |
+| Exa | ❌ | Neural semantic search (1K free/month) |
+| You.com | ❌ | AI-powered search ($5/1K, free credits available) |
 
 ---
 
@@ -216,34 +144,16 @@ mcp_servers:
 
 | Tool | Description | Best For |
 |------|-------------|----------|
-| `free_search` | Multi-engine search with auto-fallback | Quick fact-finding, general queries |
-| `free_search_advanced` | Filtered search with waterfall, domain filtering, enrichment | High-confidence results, date ranges, domain filtering |
+| `free_search` | Multi-engine search with auto-fallback | Quick fact-finding |
+| `free_search_advanced` | Filtered search with waterfall, domain filtering, enrichment | High-confidence results, date ranges |
 | `free_search_news` | News search across DDG News + Bing News | Recent news, current events |
-| `search_with_synthesis` | Deep search with `prompt_hint` for LLM synthesis | Complex queries needing multi-source verification |
-| `free_extract` | Extract full page content as Markdown | Reading a specific page from search results |
-| `fetch_github_readme` | Fetch README from a GitHub repo | Quick project documentation |
-| `fetch_csdn_article` | Fetch content from CSDN blog | Chinese developer articles |
+| `search_with_synthesis` | Deep search with prompt hint for LLM synthesis | Complex queries needing verification |
+| `free_extract` | Extract full page content as Markdown | Reading a page from search results |
+| `fetch_github_readme` | Fetch README from a GitHub repo | Project documentation |
+| `fetch_csdn_article` | Fetch content from CSDN | Chinese developer articles |
 | `fetch_juejin_article` | Fetch content from Juejin | Chinese developer articles |
 
-**Quick reference:** `free_search`, `free_search_advanced`, `free_search_news`, `search_with_synthesis`, `free_extract`, `fetch_github_readme`, `fetch_csdn_article`, `fetch_juejin_article`
-
 All tools are read-only and idempotent with MCP 2025 annotations.
-
-### Key Features
-
-**Waterfall Search** (3 phases, confidence-gated):
-1. Phase 1: DDG + Sogou → check confidence
-2. Phase 2: Bing + Baidu → check
-3. Phase 3: Brave + Tavily + Exa (paid only)
-
-Stops as soon as results are sufficient. Saves 50-75% engine calls.
-
-**Confidence Scoring** (1-3):
-- **1**: Single source
-- **2**: Verified by 2+ sources (recommended)
-- **3**: Highly verified by 3+ sources
-
-**Structured Errors**: Engine failures return typed errors (`timeout`, `rate_limited`, `permission_denied`, etc.) with actionable suggestions — agents can self-recover.
 
 ---
 
@@ -253,61 +163,48 @@ Stops as soon as results are sufficient. Saves 50-75% engine calls.
 
 | Variable | Default | Description |
 |----------|---------|-------------|
-| `BRAVE_API_KEY` | — | Brave Search API key (2K free/month) |
-| `TAVILY_API_KEY` | — | Tavily API key (1K free/month) |
-| `EXA_API_KEY` | — | Exa API key (1K free/month) |
-| `YDC_API_KEY` | — | You.com API key ($5/1K queries; sign up at you.com for free credits) |
-| `LOG_LEVEL` | `info` | Log level: `info`, `debug` |
-| `MODE` | `stdio` | Transport: `stdio`, `http`, `both` |
-| `PORT` | `3000` | HTTP server port (MODE=http/both) |
+| `BRAVE_API_KEY` | — | Brave Search API key |
+| `TAVILY_API_KEY` | — | Tavily API key |
+| `EXA_API_KEY` | — | Exa API key |
+| `YDC_API_KEY` | — | You.com API key |
+| `LOG_LEVEL` | `info` | `info` or `debug` |
+| `MODE` | `stdio` | Transport: `stdio`, `http`, or `both` |
+| `PORT` | `3000` | HTTP server port (when `MODE=http` or `both`) |
 | `OUTPUT_STYLE` | `normal` | `compact` for token-optimized output |
-| `SNIPPET_LENGTH` | `200` | Max snippet chars (60-500) |
-| `MAX_FULL_RESULTS` | `3` | Full results before compacting (compact mode, 0-20) |
-| `MIN_CONFIDENCE` | `0` | Confidence threshold filter (compact mode, 0.0-3.0) |
-| `SEMANTIC_DEDUP` | `false` | Semantic dedup via Model2Vec (<5ms, requires `pip install model2vec`) |
+| `SNIPPET_LENGTH` | `200` | Max snippet characters (60–500) |
+| `MAX_FULL_RESULTS` | `3` | Full results before compacting (compact mode) |
+| `MIN_CONFIDENCE` | `0` | Confidence threshold filter (0.0–3.0) |
+| `SEMANTIC_DEDUP` | `false` | Semantic dedup via Model2Vec (requires `pip install model2vec`) |
 | `DEDUP_THRESHOLD` | `0.85` | Cosine similarity threshold for semantic dedup |
-| `DEDUP_MODEL` | `minishlab/M2V_base_output` | Model2Vec model for dedup |
-| `SEMANTIC_RERANK` | `false` | Semantic rerank via Model2Vec (<5ms, requires `pip install model2vec`) |
+| `SEMANTIC_RERANK` | `false` | Semantic rerank via Model2Vec |
 | `RERANK_TOP_K` | `5` | Results to keep after semantic rerank |
-| `RERANK_MODEL` | `minishlab/M2V_base_output` | Model2Vec model for rerank |
 
-**Zero config works** — no API keys needed for the 8 free engines.
+**Zero config works** — the 8 free engines need no API keys.
 
 ### Tool Visibility
 
-Control which tools your agent can see:
-
 ```bash
-# Only search tools
+# Only specific tools
 ENABLED_TOOLS=free_search,free_search_advanced,free_search_news
 
 # Disable specific tools
 DISABLED_TOOLS=free_extract,fetch_github_readme
-
-# Enable only one fetch tool
-ENABLED_TOOLS=fetch_csdn_article
 ```
 
-| Variable | Description |
-|----------|-------------|
-| `ENABLED_TOOLS` | Comma-separated list of tools to enable. If set, only these are registered |
-| `DISABLED_TOOLS` | Comma-separated list of tools to disable. Takes priority over `ENABLED_TOOLS` |
+`DISABLED_TOOLS` takes priority over `ENABLED_TOOLS`.
 
 ### Engine Filtering
 
 ```bash
-# Only use Chinese engines
-ALLOWED_ENGINES=sogou,baidu
-
-# Exclude specific engines
-DENIED_ENGINES=yandex,mojeek
+ALLOWED_ENGINES=sogou,baidu    # Chinese-only
+DENIED_ENGINES=yandex,mojeek   # Exclude specific engines
 ```
 
 ---
 
 ## CLI
 
-`agent-search-mcp` also works as a standalone CLI tool (`fasm`).
+`agent-search-mcp` ships with a standalone CLI (`fasm`).
 
 ```bash
 # Search
@@ -324,68 +221,22 @@ fasm serve --port 8080
 
 ---
 
-## Architecture
+## Benchmark
 
-```
-Agent (Claude Code, Cursor, etc.)
-  ↓ MCP Protocol (stdio / Streamable HTTP)
-MCP Server
-  ├── Tools Layer
-  │   ├── free_search / free_search_advanced / free_search_news
-  │   ├── search_with_synthesis
-  │   ├── free_extract
-  │   └── fetch_github_readme / fetch_csdn_article / fetch_juejin_article
-  ├── Aggregation Layer
-  │   ├── Waterfall Search (3-phase confidence-gated)
-  │   ├── Cross-Engine Scoring (frequency + domain authority)
-  │   ├── Dedup (URL + title)
-  │   ├── Content Enrichment (Jina Reader)
-  │   └── Query Expansion (rule-based, 4 strategies)
-  ├── Engine Layer (12 engines)
-  │   ├── Free: DDG, Sogou, Bing, Baidu, Wikipedia, Startpage, Yandex, Mojeek
-  │   └── Paid (API key required): Brave, Tavily, Exa, You.com
-  └── Infrastructure
-      ├── Health Tracker (per-engine circuit breaking)
-      ├── Rate Limiter (adaptive concurrency)
-      ├── Cache (LRU, 60s TTL, 1000 entries)
-      ├── SSRF Protection (URL validation)
-      └── Security (injection detection, boundary markers)
-```
-
----
-
-## Development
-
-```bash
-git clone https://github.com/lennney/agent-search-mcp.git
-cd agent-search-mcp
-npm install
-npm run build
-npm test          # 448 tests, 40 files
-npm run dev       # stdio mode
-npm run dev:http  # HTTP mode (port 3000)
-```
-
-## Benchmarks
-
-Agent Search MCP achieved **100% success rate** across 30 diverse queries (EN + ZH), with **every query satisfied at phase 1** of the waterfall (2 engines only — no fallthrough to phase 2 or 3 needed).
+Benchmarked on [30 queries](./benchmarks/queries.json) (15 EN + 15 ZH, covering tech, news, and general knowledge) with default config, no API keys.
 
 | Metric | Result |
 |--------|--------|
-| Success rate | **30/30 (100%)** |
-| Waterfall efficiency | **100%** stopped at phase 1 |
-| Avg engines per query | **2.0** |
-| Avg confidence | 0.64 / 1.0 |
+| **Success rate** | **30/30 (100%)** |
+| **Waterfall efficiency** | **100%** stopped at phase 1 |
+| **Avg engines per query** | **2.0** (vs 8 in naive = **75% fewer calls**) |
+| **Multi-source diversity** | **0% URL overlap** DDG vs Sogou |
+| **Avg confidence** | 0.64 / 1.0 |
+| **Avg latency** | 15.2s (P50: 14.8s, P95: 18.4s) |
+| **Token savings (compact)** | **28.7%** (1582 → 1128 tokens) |
+| **Token savings (aggressive)** | **35.5%** (1582 → 1020 tokens) |
 
-→ [Full benchmark report & methodology](benchmarks/)
-
-| Metric | Value |
-|--------|-------|
-| Tests | 448 passing, 40 files |
-| Engines | 12 (8 free, 4 paid) |
-| MCP Tools | 8 |
-| Dependencies | 5 production |
-| Node.js | >= 18 |
+→ [Full methodology & reports](./benchmarks/)
 
 ---
 
@@ -399,7 +250,9 @@ mcp-slim-guard init
 mcp-slim-guard start
 ```
 
-Pair agent-search-mcp with mcp-slim-guard to get:
+```
+AI Agent → mcp-slim-guard (security + compression) → agent-search-mcp
+```
 
 | Feature | Benefit |
 |---------|---------|
@@ -410,12 +263,24 @@ Pair agent-search-mcp with mcp-slim-guard to get:
 | **Rate limiting** | Token bucket per-tool, default 60 req/min |
 | **Audit logging** | Structured JSON audit log with rotation + gzip |
 
-```
-AI Agent → mcp-slim-guard (security + compression) → agent-search-mcp
+---
+
+## Development
+
+```bash
+git clone https://github.com/lennney/agent-search-mcp.git
+cd agent-search-mcp
+npm install
+npm run build
+npm test
+npm run dev        # stdio mode
+npm run dev:http   # HTTP mode (port 3000)
 ```
 
 ---
 
 ## License
 
-[MIT](LICENSE)
+[Apache 2.0](LICENSE)
+
+Based on [open-websearch](https://github.com/Aas-ee/open-websearch) by Aas-ee.

--- a/README_zh.md
+++ b/README_zh.md
@@ -1,182 +1,77 @@
 # Agent Search MCP
 
-> 🔍 免费多源搜索 MCP 服务器 — 多源验证、Token 优化、瀑布式搜索、MCP 原生、可自托管。
+> **12 个搜索引擎（8 个免费，无需 API Key），一个 MCP Server。**
+> 搜狗 + 百度原生中文搜索。多源交叉验证 + 置信度评分。瀑布式渐进搜索。内容提取。`npx agent-search-mcp` 即可使用。
 
-[![License](https://img.shields.io/github/license/lennney/agent-search-mcp)](LICENSE)
 [![npm version](https://img.shields.io/npm/v/agent-search-mcp)](https://www.npmjs.com/package/agent-search-mcp)
 [![npm downloads](https://img.shields.io/npm/dm/agent-search-mcp)](https://www.npmjs.com/package/agent-search-mcp)
-[![Node.js](https://img.shields.io/badge/node-%3E%3D18-brightgreen)](package.json)
-[![TypeScript](https://img.shields.io/badge/TypeScript-5.3-blue)](https://www.typescriptlang.org/)
-[![MCP](https://img.shields.io/badge/MCP-compatible-blue)](https://modelcontextprotocol.io)
-[![Tests](https://img.shields.io/badge/tests-448%20passing-brightgreen)](https://github.com/lennney/agent-search-mcp)
+[![GitHub stars](https://img.shields.io/github/stars/lennney/agent-search-mcp)](https://github.com/lennney/agent-search-mcp/stargazers)
+[![CI](https://github.com/lennney/agent-search-mcp/actions/workflows/ci.yml/badge.svg)](https://github.com/lennney/agent-search-mcp/actions)
+[![License](https://img.shields.io/badge/license-Apache%202.0-blue)](LICENSE)
+[![Glama](https://glama.ai/mcp/servers/lennney/agent-search-mcp/badges/score.svg)](https://glama.ai/mcp/servers/lennney/agent-search-mcp)
 
-**兼容 Claude Code、Cursor、Windsurf、Codex、Hermes、OpenClaw 等所有 MCP 客户端。**
-
----
-
-[中文](#为什么选择-agent-search-mcp) · [English](README.md) · [安装](#quick-start) · [工具文档](#tools) · [竞品对比](#competitor-comparison)
+[English](README.md) · [Benchmarks](./benchmarks/) · [CHANGELOG](./CHANGELOG.md)
 
 ---
 
 ## 为什么选择 Agent Search MCP
 
-**AI Agent 需要搜索互联网，但现有方案都有问题：**
+大多数 MCP 搜索服务器只是封装单个付费 API — 一个引擎，一张账单。Agent Search MCP 架构完全不同。
 
-| 方案 | 价格 | 问题 |
-|------|------|------|
-| **Tavily** | $0.01/次 | 搜索多了成本高，月费 $20-50+ |
-| **Exa** | $50/月起 | 语义搜索强但太贵 |
-| **Brave Search** | 2000 次/月免费，之后 $3/1000 | 免费额度不够 |
-| **Firecrawl** | $83/10万页 | 搜索+抓取一体，但量大了贵 |
-| **Perplexity Sonar** | $5/千次 + token | 答案引擎，无法评估原始来源 |
-| **Serper** | $0.30/千次 | 谷歌 SERP，无内容提取 |
-| **DDG MCP** | 免费 | 单源、无验证、无去重、结果不稳定 |
+| | Agent Search MCP | Tavily | Exa | Brave |
+|---|:---:|:---:|:---:|:---:|
+| **价格** | **$0** | ~$30/月 | $50/月 | ~$15/月 |
+| **免费引擎数** | **8** | 0 | 0 | 1（2K/月封顶） |
+| **需要 API Key** | 不需要 | 需要 | 需要 | 需要 |
+| **多源验证** | ✅ 8 引擎交叉验证 | ❌ | ❌ | ❌ |
+| **中文搜索** | ✅ 搜狗+百度 | ❌ | ❌ | ❌ |
+| **自托管** | ✅ | ❌ | ❌ | ❌ |
 
-**Agent Search MCP 的差异化：**
+### 完全免费
 
-### 核心搜索能力
+8 个引擎零配置即可使用 — DuckDuckGo、搜狗、Bing、百度、Wikipedia、Startpage、Yandex、Mojeek。无需 API Key，无需注册，无需信用卡。按每天 100 次搜索算，比付费方案省 $30–50/月。
 
-| 特性 | 说明 |
-|------|------|
-| **默认免费** | DuckDuckGo + Sogou + Bing + Baidu 为核心，无需 API Key。Brave + Tavily + Exa 作为可选付费 fallback |
-| **瀑布式渐进搜索** 🆕 | 3 阶段置信度门控搜索：(1) DDG+Sogou → 检查 → (2) Bing+Baidu → 检查 → (3) Brave+Tavily+Exa。置信度达标即停，节省 50-75% 引擎调用 |
-| **多源验证** | 跨引擎交叉验证，每个结果有置信度评分（1-3），≥2 的结果经过至少 2 个引擎验证 |
-| **内容丰富化** 🆕 | 低置信度/摘要过短的结果，自动通过 Jina Reader 提取全文回填。置信度提升 +0.33（上限 1.0） |
-| **域名权威评分** 🆕 | `.edu`/`.gov`/`.ac.xx` 域名 +0.12；高质量站点（wikipedia、stackoverflow、arxiv）加分；低质域名扣分 |
-| **自适应查询扩展** 🆕 | 置信度不足时自动生成 2 个备选查询重搜，4 种规则策略（vs-split、前缀剥离、核心关键词、技术同义词），无需 LLM |
+### 减少 75% 引擎调用
 
-### Token 与成本优化
+基于 [30 条多样化查询](./benchmarks/)（15 条英文 + 15 条中文）的基准测试：**100% 在瀑布阶段一即满足要求**，仅需 2 个引擎。简单多引擎搜索每次都调全部 8 个引擎。瀑布式搜索在置信度足够时提前停止 — 更少调用、更低延迟、更少数据喂给 LLM。
 
-| 特性 | 说明 |
-|------|------|
-| **Token 优化** | 标题 ≤100 字符，摘要 ≤200 字符，URL + 标题去重。节省 ~40-50% token 消耗 |
-| **渐进式披露** | 3 个工具按复杂度递增：`free_search` 快速问答、`free_search_advanced` 过滤搜索+瀑布流程、`free_extract` 页面提取。Agent 按需发现 |
+### 多源交叉验证
 
-### 可靠性
+DDG 和搜狗返回**零重叠结果集** — 覆盖面真正比单一引擎更广。每个结果经多源比对后给出 1–3 分置信度评分。置信度 ≥2 的结果经过至少 2 个引擎交叉验证。
 
-| 特性 | 说明 |
-|------|------|
-| **Fallback 机制** | 免费引擎优先，付费引擎备用。自动合并、去重、评分 |
-| **健康监控** | 实时追踪 Provider 健康状态，失败 Provider 自动过滤 |
-| **限速保护** | 每个 Provider 最小请求间隔 1 秒 |
-| **智能缓存** | LRU 缓存，60 秒 TTL，最多 1000 条目 |
+### Token 省在架构里
 
-### 安全
+两层节省机制，基于 30 条 EN+ZH 查询的基准测试：
+- **瀑布提前停止** → 调 2 个而非 8 个引擎 → **减少 75% 引擎调用**
+- **Compact 模式** → 去除元数据噪声 + 渐进式披露 → **减少 28.7% token**（1582 → 1128）
+- **Compact Aggressive**（`SNIPPET_LENGTH=120`）→ **减少 35.5% token**（1582 → 1020）
 
-| 特性 | 说明 |
-|------|------|
-| **Prompt 注入检测** | 阻拦搜索请求中的注入模式 |
-| **输出边界标记** | 系统输出和搜索结果之间的清晰分隔 |
-| **钓鱼 URL 过滤** | 检测并标记可疑 URL |
-| **SSRF 保护** | 禁止私网 IP、localhost、元数据端点 |
-| **安全元数据** | 每次响应附带安全上下文 |
+### 原生中文搜索
 
----
-
-## 成本对比
-
-假设每天搜索 100 次：
-
-| 方案 | 月费 | 年费 |
-|------|------|------|
-| Tavily | ~$30 | ~$360 |
-| Exa | $50 | $600 |
-| Brave Search | ~$15 | ~$180 |
-| Firecrawl | ~$25 | ~$300 |
-| Perplexity Sonar | ~$30 | ~$360 |
-| Serper | ~$9 | ~$108 |
-| **Agent Search MCP** | **$0** | **$0** |
-
----
-
-## Competitor Comparison
-
-| Feature | Agent Search MCP | Tavily | Exa | Brave Search | Firecrawl | Perplexity Sonar | Serper | DDG MCP |
-|---------|:---:|:---:|:---:|:---:|:---:|:---:|:---:|:---:|
-| **价格** | 免费 | $0.01/次 | $50/月 | $3/1000 | $83/10万页 | $5/千次+token | $0.30/千次 | 免费 |
-| **API Key** | 不需要 | 需要 | 需要 | 需要 | 需要 | 需要 | 需要 | 需要 |
-| **免费额度** | 无限 | 1千/月 | $10 额度 | 2千/月 | 有限 | 无 | 2.5千/月 | 无限 |
-| **多源验证** | ✅ 4+ 引擎 | ❌ 单源 | ❌ 单源 | ❌ 单源 | ❌ 单源 | ❌ 单源 | ❌ 单源 | ❌ 单源 |
-| **瀑布搜索** | ✅ 置信度门控 | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ |
-| **内容丰富化** | ✅ 自动提取 | ✅ (内置) | ✅ (内置) | ❌ | ✅ (内置) | ✅ (合成) | ❌ | ❌ |
-| **查询扩展** | ✅ 规则引擎 | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ |
-| **置信度评分** | ✅ 1-3 | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ |
-| **域名权威** | ✅ Edu/Gov 加分 | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ |
-| **去重** | ✅ URL+标题 | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ |
-| **Token 优化** | ✅ ~40-50% | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ |
-| **中文搜索** | ✅ 搜狗+百度 | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ |
-| **语义搜索** | ❌ (规划中) | ❌ | ✅ 神经 | ❌ | ❌ | ❌ | ❌ | ❌ |
-| **答案引擎** | ❌ (规划中) | ❌ | ❌ | ❌ | ❌ | ✅ 合成 | ❌ | ❌ |
-| **人/公司搜索** | ❌ (规划中) | ❌ | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ |
-| **MCP 原生** | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
-| **可自托管** | ✅ | ❌ 仅云端 | ❌ 仅云端 | ❌ 仅云端 | ❌ 仅云端 | ❌ 仅云端 | ❌ 仅云端 | ✅ |
-| **安全** | ✅ 注入保护 | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ |
-| **依赖数量** | 4 | 12+ | 15+ | 8 | 10+ | 8+ | 5 | 3 |
-
-**核心差异：**
-
-1. **默认免费** — 无需 API Key，无需信用卡，无限制。DDG + Sogou + Bing + Baidu 开箱即用
-2. **多源验证** — 跨引擎交叉验证，置信度告诉你结果有多可靠
-3. **瀑布式搜索** — 独特的多阶段置信度门控搜索，质量达标即停，节省引擎调用和 Token
-4. **Token 优化** — 智能截断和去重减少 ~40-50% 消耗
-5. **中国搜索引擎** — 搜狗 + 百度提供原生中文搜索，不需要翻译层
-6. **安全性** — 内置 Prompt 注入检测、钓鱼 URL 过滤、输出边界标记
-
-**我方差距（规划中）：**
-- **语义/神经搜索** — Exa 的神经索引处理概念型查询。可添加 embedding 搜索
-- **答案引擎** — 类似 Perplexity 的多源结果 LLM 合成直接答案
-- **人/公司搜索** — Exa 的实体索引，用于销售/情报场景
+搜狗 + 百度直接搜索中文互联网 — 微信公众号内容、百度百科、中文技术论坛。不是翻译层，不是附属功能。
 
 ---
 
 ## 快速开始
 
-### 前置条件
-
-- Node.js >= 18
-
-安装即用，无需额外依赖。
-
-> **可选：** 安装 Python + ddgs 可获得更好的 DuckDuckGo 结果：
-> ```bash
-> pip install ddgs
-> ```
-> 不安装时 DuckDuckGo 自动使用 Node.js HTML 引擎。
-
-### 安装
-
 ```bash
-# 方式 1：npx（推荐）
+# 一条命令 — 无需安装，无需 API Key
 npx agent-search-mcp
-
-# 方式 2：全局安装
-npm install -g agent-search-mcp
 ```
 
-### Platform Setup
+需要 Node.js >= 18。
+
+### 客户端配置
 
 <details>
-<summary><b>Hermes</b></summary>
-
-```yaml
-# ~/.hermes/config.yaml
-mcp_servers:
-  agent-search:
-    command: npx
-    args: ["agent-search-mcp"]
-```
-</details>
-
-<details>
-<summary><b>Claude Code</b></summary>
+<summary><b>Claude Code / Claude Desktop</b></summary>
 
 ```json
-// ~/.claude/mcp.json
 {
   "mcpServers": {
     "agent-search": {
       "command": "npx",
-      "args": ["agent-search-mcp"]
+      "args": ["-y", "agent-search-mcp"]
     }
   }
 }
@@ -184,15 +79,14 @@ mcp_servers:
 </details>
 
 <details>
-<summary><b>Cursor</b></summary>
+<summary><b>Cursor / VS Code / Codex</b></summary>
 
 ```json
-// .cursor/mcp.json
 {
   "mcpServers": {
     "agent-search": {
       "command": "npx",
-      "args": ["agent-search-mcp"]
+      "args": ["-y", "agent-search-mcp"]
     }
   }
 }
@@ -203,12 +97,11 @@ mcp_servers:
 <summary><b>Windsurf</b></summary>
 
 ```json
-// ~/.codeium/windsurf/mcp_config.json
 {
   "mcpServers": {
     "agent-search": {
       "command": "npx",
-      "args": ["agent-search-mcp"]
+      "args": ["-y", "agent-search-mcp"]
     }
   }
 }
@@ -216,313 +109,140 @@ mcp_servers:
 </details>
 
 <details>
-<summary><b>OpenClaw</b></summary>
+<summary><b>Hermes</b></summary>
 
-```typescript
-// openclaw.config.ts
-{
-  mcpServers: {
-    "agent-search": {
-      command: "npx",
-      args: ["agent-search-mcp"]
-    }
-  }
-}
-```
-</details>
-
-<details>
-<summary><b>Codex</b></summary>
-
-```json
-// ~/.codex/mcp.json
-{
-  "mcpServers": {
-    "agent-search": {
-      "command": "npx",
-      "args": ["agent-search-mcp"]
-    }
-  }
-}
+```yaml
+mcp_servers:
+  agent-search:
+    command: npx
+    args: ["-y", "agent-search-mcp"]
 ```
 </details>
 
 ---
 
-## CLI 使用
+## 搜索引擎
 
-agent-search-mcp 也可以作为 CLI 工具使用。
+| 引擎 | 免费 | 优势 |
+|------|:----:|------|
+| **DuckDuckGo** | ✅ | 隐私保护，英文搜索 |
+| **搜狗** | ✅ | 中文网页搜索，微信公众号内容 |
+| **Bing** | ✅ | 多语言，英文结果好 |
+| **百度** | ✅ | 中文网页搜索，百度百科 |
+| **Wikipedia** | ✅ | 结构化知识，JSON API |
+| **Startpage** | ✅ | Google 结果通过隐私代理 |
+| **Yandex** | ✅ | 俄语/西里尔语搜索 |
+| **Mojeek** | ✅ | 独立爬虫，隐私优先 |
+| Brave Search | ❌ | 高质量网页搜索（2K 免费/月） |
+| Tavily | ❌ | Agent 优化搜索（1K 免费/月） |
+| Exa | ❌ | 神经语义搜索（1K 免费/月） |
+| You.com | ❌ | AI 驱动搜索（$5/千次，有免费额度） |
 
-### 安装
+---
+
+## 工具
+
+| 工具 | 说明 | 适用场景 |
+|------|------|----------|
+| `free_search` | 多引擎搜索 + 自动回退 | 快速查事实 |
+| `free_search_advanced` | 过滤搜索 + 瀑布流程 + 内容丰富化 | 高置信度结果、时间过滤 |
+| `free_search_news` | DDG 新闻 + Bing 新闻 | 时事新闻 |
+| `search_with_synthesis` | 深度搜索 + LLM 综合提示 | 复杂查询需多源验证 |
+| `free_extract` | 提取完整页面为 Markdown | 阅读搜索结果中的页面 |
+| `fetch_github_readme` | 获取 GitHub 仓库 README | 项目文档查阅 |
+| `fetch_csdn_article` | 获取 CSDN 文章内容 | 中文开发者文章 |
+| `fetch_juejin_article` | 获取掘金文章内容 | 中文开发者文章 |
+
+所有工具均为只读、幂等，带 MCP 2025 注解。
+
+---
+
+## 配置
+
+### 环境变量
+
+| 变量 | 默认值 | 说明 |
+|------|--------|------|
+| `BRAVE_API_KEY` | — | Brave Search API Key |
+| `TAVILY_API_KEY` | — | Tavily API Key |
+| `EXA_API_KEY` | — | Exa API Key |
+| `YDC_API_KEY` | — | You.com API Key |
+| `LOG_LEVEL` | `info` | 日志级别：`info` 或 `debug` |
+| `MODE` | `stdio` | 传输方式：`stdio`、`http` 或 `both` |
+| `PORT` | `3000` | HTTP 服务端口（`MODE=http` 或 `both` 时） |
+| `OUTPUT_STYLE` | `normal` | `compact` 开启 token 优化输出 |
+| `SNIPPET_LENGTH` | `200` | 摘要最大字符数（60–500） |
+| `MAX_FULL_RESULTS` | `3` | compact 模式下的完整结果数 |
+| `MIN_CONFIDENCE` | `0` | 置信度过滤阈值（0.0–3.0） |
+| `SEMANTIC_DEDUP` | `false` | 语义去重（需 `pip install model2vec`） |
+| `DEDUP_THRESHOLD` | `0.85` | 语义去重的余弦相似度阈值 |
+| `SEMANTIC_RERANK` | `false` | 语义重排（需 `pip install model2vec`） |
+| `RERANK_TOP_K` | `5` | 语义重排保留的结果数 |
+
+**零配置即可使用** — 8 个免费引擎无需任何 API Key。
+
+### 工具可见性
 
 ```bash
-npm install -g agent-search-mcp
+# 只启用指定工具
+ENABLED_TOOLS=free_search,free_search_advanced,free_search_news
+
+# 禁用指定工具
+DISABLED_TOOLS=free_extract,fetch_github_readme
 ```
 
-### 搜索
+`DISABLED_TOOLS` 优先级高于 `ENABLED_TOOLS`。
+
+### 引擎过滤
 
 ```bash
-# 基础搜索
+ALLOWED_ENGINES=sogou,baidu    # 只用中文引擎
+DENIED_ENGINES=yandex,mojeek   # 排除特定引擎
+```
+
+---
+
+## CLI
+
+`agent-search-mcp` 附带独立的命令行工具（`fasm`）。
+
+```bash
+# 搜索
 fasm search "TypeScript MCP server"
+fasm search "关键词" --count 5 --engines bing,baidu,youcom --json
 
-# 指定数量和引擎
-fasm search "query" --count 5 --engines bing,baidu
-
-# JSON 输出
-fasm search "query" --json
-```
-
-### 提取网页
-
-```bash
+# 提取网页
 fasm extract "https://example.com"
 fasm extract "https://example.com" --json
-```
 
-### 启动 HTTP 服务
-
-```bash
+# HTTP 服务
 fasm serve --port 8080
 ```
 
-### 帮助
-
-```bash
-fasm --help
-```
-
 ---
 
-## Tools
+## 基准测试
 
-### `free_search`
+基于 [30 条查询](./benchmarks/queries.json)（15 EN + 15 ZH，覆盖技术、新闻、通用知识），默认配置，无 API Key。
 
-基础搜索，多源验证。
-
-```json
-{
-  "query": "TypeScript MCP server",
-  "count": 5
-}
-```
-
-**返回：** 带置信度评分（1-3）的搜索结果数组。
-
-### `free_search_advanced`
-
-高级搜索，支持瀑布式渐进搜索、过滤和内容丰富化。
-
-```json
-{
-  "query": "MCP server",
-  "count": 10,
-  "min_confidence": 2,
-  "time_range": "week",
-  "language": "zh",
-  "include_domains": ["github.com"],
-  "exclude_domains": ["reddit.com"]
-}
-```
-
-**参数：**
-- `min_confidence` (1-3)：只返回经过 N+ 引擎验证的结果
-- `time_range`：day、week、month、year
-- `language`：auto、en、zh
-- `include_domains`：只搜索这些域名
-- `exclude_domains`：排除这些域名
-
-**瀑布流程（默认开启）：**
-1. 阶段 1：DDG + Sogou → 检查置信度篮子
-2. 阶段 2（如果需要）：Bing + Baidu → 检查篮子
-3. 阶段 3（如果需要）：Brave + Tavily + Exa（付费引擎）
-4. 内容丰富化：低置信度结果自动通过 Jina Reader 提取全文
-5. 查询扩展（篮子仍不足）：自动生成备选查询
-
-### `free_extract`
-
-URL 内容提取，获取完整 Markdown。
-
-```json
-{
-  "url": "https://example.com/article",
-  "max_length": 5000
-}
-```
-
-**返回：** Markdown 格式内容及元数据。超过 `max_length` 的完整文本存储在磁盘。
-
----
-
-## Resources
-
-### `search://capabilities`
-
-返回描述所有可用工具和功能的 Markdown 文档。Agent 可按需发现能力。
-
-### `search://health`
-
-返回 JSON 格式的 Provider 健康状态。用于监控和调试。
-
----
-
-## Configuration
-
-### Environment Variables
-
-| Variable | Description | Required |
-|----------|-------------|----------|
-| `BRAVE_API_KEY` | Brave Search API key（2000 免费/月） | No |
-| `TAVILY_API_KEY` | Tavily API key（1000 免费/月） | No |
-| `EXA_API_KEY` | Exa API key（1000 免费/月） | No |
-| `LOG_LEVEL` | 日志级别（info, debug） | No |
-
-**零配置可用** — DDG + Sogou + Bing + Baidu 基础搜索无需 API Key。
-
-### 启用付费引擎
-
-设置环境变量以启用付费引擎 fallback：
-
-```bash
-export BRAVE_API_KEY=your_key_here
-export TAVILY_API_KEY=your_key_here
-export EXA_API_KEY=your_key_here
-```
-
----
-
-## 依赖项
-
-| 依赖 | 许可证 | 用途 |
-|------|--------|------|
-| @modelcontextprotocol/sdk | MIT | MCP 协议 |
-| zod | MIT | Schema 验证 |
-| pino | MIT | 日志 |
-| yaml | ISC | 配置解析 |
-| cheerio | MIT | DuckDuckGo HTML 解析器（Node.js 原生） |
-| ddgs (Python, 可选) | MIT | 增强的 DuckDuckGo 后端（绕过反爬） |
-
----
-
-## Architecture
-
-```
-Agent
-  ↓ MCP Protocol (stdio / HTTP)
-MCP Server
-  ├── Tools Layer
-  │   ├── free_search (快速查询)
-  │   ├── free_search_advanced (瀑布 + 过滤)
-  │   └── free_extract (页面提取)
-  ├── Aggregation Layer
-  │   ├── Waterfall Search Engine      ← 新增
-  │   │   ├── Phase 1: DDG + Sogou
-  │   │   ├── Phase 2: Bing + Baidu
-  │   │   └── Phase 3: Brave + Tavily + Exa (付费)
-  │   ├── Content Enricher (Jina)      ← 新增
-  │   ├── Domain Authority Scorer       ← 新增
-  │   ├── Query Expander (Rule Engine)  ← 新增
-  │   ├── Confidence Basket Checker     ← 新增
-  │   ├── Top-1 Snippet 合并
-  │   ├── URL + 标题去重
-  │   ├── 评分 + 置信度
-  │   └── 输出截断
-  ├── Security Layer
-  │   ├── Prompt 注入检测
-  │   ├── 输出边界标记
-  │   ├── 钓鱼 URL 过滤
-  │   └── 安全元数据
-  ├── Fallback Chain
-  │   ├── 阶段 1：免费引擎 (DDG + Sogou + Bing + Baidu)
-  │   └── 阶段 2：付费引擎 (Brave + Tavily + Exa)
-  └── Infrastructure
-      ├── Cache (LRU, 60s TTL)
-      ├── Rate Limiter (1s per provider)
-      ├── Health Tracker
-      └── SSRF Protection
-```
-
----
-
-## 项目数据
-
-| 指标 | 数值 |
+| 指标 | 结果 |
 |------|------|
-| 测试数量 | **149**（13 个文件） |
-| 源码量 | ~2,500 行 TypeScript |
-| 免费引擎 | 4（DDG + Sogou + Bing + Baidu） |
-| 付费引擎 | 3（Brave + Tavily + Exa） |
-| npm 生产依赖 | 4 |
-| 引擎总计 | 7 |
+| **成功率** | **30/30 (100%)** |
+| **瀑布效率** | **100%** 在阶段一停止 |
+| **平均引擎数** | **2.0**（对比 8 引擎全量 = **减少 75% 调用**）|
+| **多源多样性** | DDG 与搜狗 **0% URL 重叠** |
+| **平均置信度** | 0.64 / 1.0 |
+| **平均延迟** | 15.2s（P50: 14.8s, P95: 18.4s）|
+| **Token 节省（compact）** | **28.7%**（1582 → 1128 tokens）|
+| **Token 节省（aggressive）** | **35.5%**（1582 → 1020 tokens）|
+
+→ [完整方法与报告](./benchmarks/)
 
 ---
 
-## Documentation / 文档
+## 配套工具
 
-| Document | Description |
-|----------|-------------|
-| [PRD](docs/prd.md) | 产品需求文档 |
-| [Architecture](docs/architecture.md) | 技术架构 |
-| [Plan](docs/plan.md) | 实现计划 |
-| [Review Results](docs/review-results.md) | 5 团队评审结果 |
-| [Fork Plan](docs/fork-plan.md) | Fork 改造方案 |
-| [CHANGELOG](CHANGELOG.md) | 版本历史 |
-
----
-
-## Development
-
-```bash
-# 克隆
-git clone https://github.com/lennney/agent-search-mcp.git
-cd agent-search-mcp
-
-# 安装
-npm install
-
-# 构建
-npm run build
-
-# 测试
-npm test
-
-# 运行
-npm start
-```
-
----
-
-## Roadmap
-
-- [x] DDG + Sogou 免费引擎、多源验证、去重、评分
-- [x] Bing + Baidu 引擎、HTTP/SSE 模式、安全层、配置模块
-- [x] CLI 二进制 (`fasm`)、ContextManager、双模式服务
-- [x] **瀑布搜索、内容丰富化、域名权威、查询扩展** ← 当前版本
-- [ ] 语义/神经搜索（基于 embedding 的概念匹配）
-- [ ] 答案引擎模式（多源结果 + LLM 综合）
-- [ ] 实体搜索（人物、公司、代码）
-- [ ] 插件系统（自定义引擎）
-- [ ] 浏览器提取（Playwright）
-
----
-
-## License
-
-[Apache License 2.0](LICENSE)
-
-Based on [open-websearch](https://github.com/Aas-ee/open-websearch) by Aas-ee.
-
-```
-Copyright 2025 Open-WebSearch MCP Server Contributors
-Based on open-websearch by Aas-ee (Apache 2.0).
-Modified by Agent Search MCP Contributors.
-Copyright 2026 Agent Search MCP Contributors
-```
-
----
-
-## 🔗 推荐搭配
-
-**🛡️ [mcp-slim-guard](https://github.com/lennney/mcp-slim-guard)** — 给你的 MCP 栈添加安全 + 压缩
+**🛡️ [mcp-slim-guard](https://github.com/lennney/mcp-slim-guard)** — 为你的 MCP 栈添加安全 + 压缩
 
 ```bash
 npm install -g mcp-slim-guard
@@ -530,23 +250,37 @@ mcp-slim-guard init
 mcp-slim-guard start
 ```
 
-agent-search-mcp + mcp-slim-guard = 搜索 + 安全 + Token 节省三合一：
-
-| 功能 | 效果 |
-|------|------|
-| **Schema 压缩** | 节省 ~83% 上下文窗口 — 1,736 → 300 tokens |
-| **工具白名单** | Glob 模式控制哪些工具可调用 |
-| **SSRF 保护** | IP 黑名单 + 域名白名单，阻止内网请求 |
-| **注入检测** | 17 种启发式模式，防提示注入/SQL/Shell |
-| **速率限制** | 每工具 Token Bucket，默认 60 req/min |
-| **审计日志** | 结构化 JSON 日志，支持轮转 + gzip |
-
 ```
 AI Agent → mcp-slim-guard (安全 + 压缩) → agent-search-mcp
 ```
 
+| 功能 | 效果 |
+|------|------|
+| **Schema 压缩** | 回收约 83% 上下文窗口 — 1,736 → 300 tokens |
+| **工具白名单** | Glob 模式控制哪些工具可调用 |
+| **SSRF 保护** | IP 黑名单 + 域名白名单，拦截内网请求 |
+| **注入检测** | 17 种启发式模式，防提示注入/SQL/Shell |
+| **速率限制** | 每工具 Token Bucket，默认 60 req/min |
+| **审计日志** | 结构化 JSON 日志，支持轮转 + gzip |
+
 ---
 
-## Contributing
+## 开发
 
-欢迎贡献！请先阅读 [CONTRIBUTING.md](CONTRIBUTING.md)。
+```bash
+git clone https://github.com/lennney/agent-search-mcp.git
+cd agent-search-mcp
+npm install
+npm run build
+npm test
+npm run dev        # stdio 模式
+npm run dev:http   # HTTP 模式（端口 3000）
+```
+
+---
+
+## 许可证
+
+[Apache 2.0](LICENSE)
+
+基于 [open-websearch](https://github.com/Aas-ee/open-websearch) by Aas-ee。

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -1,31 +1,66 @@
 # Benchmarks
 
-Reproducible performance benchmarks for Agent Search MCP.
+Reproducible benchmarks measuring search quality, engine efficiency, and token optimization.
 
-## Latest Results
+## Latest Results (2026-07-24)
 
-| Metric | Value |
-|--------|-------|
-| Success rate | **100%** (30/30) |
-| Waterfall efficiency | **100%** stopped at phase 1 |
-| Avg engines per query | **2.0** |
-| Date | 2026-07-23 |
+30 queries (15 EN + 15 ZH), default config, no API keys. Token counts via character estimation (~1 token per 3 chars).
 
-[Full report →](./reports/2026-07-23.md)
+| Metric | Normal | Compact | Compact+ |
+|--------|--------|---------|----------|
+| **Success rate** | 100% | 100% | 96.7% |
+| **Avg engines** | 2.0 | 2.0 | 2.0 |
+| **Waterfall phase 1** | 100% | 100% | 100% |
+| **Avg tokens** | 1582 | 1128 | 1020 |
+| **Token savings vs Normal** | — | **28.7%** | **35.5%** |
+| **Avg latency** | 15.2s | 16.6s | 16.2s |
+| **P50 latency** | 14.8s | 16.3s | 15.9s |
+| **P95 latency** | 18.4s | 19.9s | 19.3s |
+
+→ [Full report](./reports/2026-07-24.md) · [JSON data](./reports/2026-07-24.json)
+
+Key findings:
+- **100% waterfall efficiency** — every query satisfied at phase 1 (2 engines). Saves 75% vs naive 8-engine search.
+- **28.7% token reduction** with compact mode (progressive disclosure + metadata stripping)
+- **35.5% token reduction** with aggressive settings (compact + 120-char snippets)
+- **0% URL overlap** between DDG and Sogou — genuine multi-source diversity
+
+### Historical
+
+| Date | Success | Tokens (Normal) | Compact Savings | Report |
+|------|---------|-----------------|-----------------|--------|
+| 2026-07-24 | 100% | 1582 | 28.7% | [report](./reports/2026-07-24.md) |
+| 2026-07-23 | 100% | — | 6.7% (bytes) | [report](./reports/2026-07-23.md) |
 
 ## How to Run
 
 ```bash
+# Build first
+npm run build
+
+# Run benchmarks (3 scenarios: normal, compact, compact+aggressive)
 node benchmarks/run.cjs
 ```
 
-Output: console summary + JSON report in `reports/`.
+**Optional: install tiktoken for precise token counts** (otherwise falls back to character estimation):
+
+```bash
+pip install tiktoken
+```
+
+## Scenarios Tested
+
+| Scenario | OUTPUT_STYLE | MAX_FULL_RESULTS | SNIPPET_LENGTH |
+|----------|-------------|-----------------|----------------|
+| Normal | (default) | — | 200 |
+| Compact | compact | 3 | 200 |
+| Compact Aggressive | compact | 3 | 120 |
 
 ## Contents
 
 | File | Description |
 |------|-------------|
-| [`queries.json`](./queries.json) | 30 test queries (15 EN + 15 ZH) |
-| [`run.cjs`](./run.cjs) | Benchmark runner script |
+| [`queries.json`](./queries.json) | 30 test queries (15 EN + 15 ZH, tech/news/general) |
+| [`run.cjs`](./run.cjs) | Benchmark runner with optional tiktoken support |
 | [`methodology.md`](./methodology.md) | Testing methodology |
 | [`reports/`](./reports) | Published benchmark reports |

--- a/benchmarks/reports/2026-07-24.json
+++ b/benchmarks/reports/2026-07-24.json
@@ -1,0 +1,40 @@
+{
+  "date": "2026-07-24",
+  "queries": 30,
+  "tokenCounter": "estimate",
+  "scenarios": {
+    "Normal (waterfall, default)": {
+      "successRate": "100.0%",
+      "avgEngines": "2.0",
+      "waterfallPhase1Rate": "100%",
+      "avgTokens": 1582,
+      "avgDuration": "15153ms",
+      "p50": "14801ms",
+      "p95": "18351ms",
+      "avgConfidence": "0.64"
+    },
+    "Compact (progressive disclosure)": {
+      "successRate": "100.0%",
+      "avgEngines": "2.0",
+      "waterfallPhase1Rate": "100%",
+      "avgTokens": 1128,
+      "avgDuration": "16569ms",
+      "p50": "16310ms",
+      "p95": "19919ms",
+      "avgConfidence": "0.64"
+    },
+    "Compact Aggressive (short snippets)": {
+      "successRate": "96.7%",
+      "avgEngines": "2.0",
+      "waterfallPhase1Rate": "100%",
+      "avgTokens": 1020,
+      "avgDuration": "16249ms",
+      "p50": "15948ms",
+      "p95": "19326ms",
+      "avgConfidence": "0.63"
+    }
+  },
+  "compactTokenSavings": "28.7%",
+  "compactAggressiveTokenSavings": "35.5%",
+  "waterfallEngineSavings": "75%"
+}

--- a/benchmarks/reports/2026-07-24.md
+++ b/benchmarks/reports/2026-07-24.md
@@ -1,0 +1,32 @@
+# Benchmark Report — 2026-07-24
+
+Token counter: **estimate**
+
+## Results (30 queries: 15 EN + 15 ZH)
+
+| Metric | Normal | Compact | Compact Aggressive |
+|--------|--------|---------|-------------------|
+| Success rate | 100.0% | 100.0% | 96.7% |
+| Avg engines/query | 2.0 | 2.0 | 2.0 |
+| Waterfall phase 1 | 100% | 100% | 100% |
+| Avg tokens | 1582 | 1128 | 1020 |
+| Avg latency | 15153ms | 16569ms | 16249ms |
+| P50 latency | 14801ms | 16310ms | 15948ms |
+| P95 latency | 18351ms | 19919ms | 19326ms |
+| Avg confidence | 0.64 | 0.64 | 0.63 |
+
+## Token Savings
+
+| Comparison | Savings |
+|------------|---------|
+| Compact vs Normal | **28.7%** |
+| Compact Aggressive vs Normal | **35.5%** |
+| Waterfall vs naive 8-engine | **75% fewer calls** |
+
+## Configuration
+
+| Scenario | OUTPUT_STYLE | MAX_FULL_RESULTS | SNIPPET_LENGTH |
+|----------|-------------|-----------------|----------------|
+| Normal | (default) | — | 200 |
+| Compact | compact | 3 | 200 |
+| Compact Aggressive | compact | 3 | 120 |

--- a/benchmarks/run.cjs
+++ b/benchmarks/run.cjs
@@ -7,72 +7,97 @@ const REPORTS_DIR = path.join(__dirname, 'reports');
 
 const queries = JSON.parse(fs.readFileSync(QUERIES_FILE, 'utf-8'));
 
-/**
- * Parse the mixed NDJSON+JSON output from fasm.
- * Log lines are single-line JSON objects. The final result is a multi-line JSON object.
- * Strategy: find the last occurrence of a root JSON object by bracket matching.
- */
+// ── Optional tiktoken ─────────────────────────────────────────────────
+let tokenCounter;
+try {
+  // Try Python tiktoken via child process
+  const { execSync } = require('child_process');
+  execSync('python3 -c "import tiktoken; enc=tiktoken.get_encoding(\"cl100k_base\"); print(enc.encode(\"test\").__len__())"', {
+    stdio: 'pipe', timeout: 5000
+  });
+  tokenCounter = 'tiktoken';
+  console.log('Token counter: tiktoken (cl100k_base) ✓');
+} catch {
+  tokenCounter = 'estimate';
+  console.log('Token counter: estimation (~1 token per 3 chars) — install tiktoken for precise counts');
+}
+
+function countTokens(text) {
+  if (tokenCounter === 'tiktoken') {
+    try {
+      const { execSync } = require('child_process');
+      // Pipe text via stdin to avoid shell escaping issues
+      const result = execSync(
+        `python3 -c "import sys,tiktoken; enc=tiktoken.get_encoding('cl100k_base'); print(len(enc.encode(sys.stdin.read())))"`,
+        { input: text, timeout: 5000, maxBuffer: 10 * 1024 * 1024 }
+      );
+      return parseInt(result.toString().trim(), 10);
+    } catch {
+      // Fall back to estimation
+    }
+  }
+  // Character-based estimation: ~1 token per 3 chars for mixed EN+ZH
+  return Math.max(1, Math.round(text.length / 3.0));
+}
+
+// ── Parse mixed NDJSON + multi-line JSON output ──────────────────────
 function parseOutput(raw) {
-  // Remove NDJSON log lines (single-line JSON objects that don't contain 'results')
-  // We want the last JSON blob that has a "results" array
+  // Strategy: find JSON lines that are NOT NDJSON (don't start with {"level")
+  // Collect them into a candidate, try to parse as JSON, look for "results"
   const lines = raw.split('\n');
   
-  // Find the start of the result JSON: look for a line that starts with "{" after log lines end
-  let resultLines = [];
-  let inResult = false;
-  let braceDepth = 0;
-  
-  for (let i = lines.length - 1; i >= 0; i--) {
-    const trimmed = lines[i].trim();
-    // Count braces to find top-level JSON
-    for (const ch of trimmed) {
-      if (ch === '}') braceDepth--;
-      else if (ch === '{') braceDepth++;
-    }
-    resultLines.unshift(lines[i]);
-    if (braceDepth === 0 && resultLines.length > 1) {
-      // Found a complete JSON object
-      const candidate = resultLines.join('\n');
-      try {
-        const parsed = JSON.parse(candidate);
-        if (parsed && parsed.results) {
-          return parsed;
+  // Remove NDJSON log lines and plain text errors
+  const jsonLines = lines.filter(l => {
+    const t = l.trim();
+    if (!t) return false;
+    if (t.startsWith('{"level"')) return false; // NDJSON log
+    if (!t.startsWith('{') && !t.startsWith('[') && !t.startsWith('"')) return false; // plain text error
+    return true;
+  });
+
+  // Try the combined JSON
+  const candidate = jsonLines.join('\n');
+  try {
+    const parsed = JSON.parse(candidate);
+    if (parsed && 'results' in parsed) return parsed;
+  } catch {
+    // Try each bracket-balanced block
+    let depth = 0;
+    let start = -1;
+    for (let i = 0; i < lines.length; i++) {
+      const trimmed = lines[i].trim();
+      if (trimmed.startsWith('{"level"')) continue;
+      for (const ch of trimmed) {
+        if (ch === '{' || ch === '[') {
+          if (depth === 0) start = i;
+          depth++;
+        } else if (ch === '}' || ch === ']') {
+          depth--;
+          if (depth === 0 && start >= 0) {
+            const block = lines.slice(start, i + 1).join('\n');
+            try {
+              const parsed = JSON.parse(block);
+              if (parsed && 'results' in parsed) return parsed;
+            } catch {}
+            start = -1;
+          }
         }
-      } catch {
-        // not valid JSON, continue searching
       }
-      break;
     }
   }
-  
-  // Try another approach: find by scanning forward
-  for (let i = 0; i < lines.length; i++) {
-    if (lines[i].trim().startsWith('{') && !lines[i].includes('"level"')) {
-      const candidate = lines.slice(i).join('\n');
-      try {
-        const parsed = JSON.parse(candidate);
-        if (parsed && parsed.results) {
-          return parsed;
-        }
-      } catch {}
-    }
-  }
-  
   return null;
 }
 
-function runSearch(query, count = 10, compact = false) {
+// ── Run search ────────────────────────────────────────────────────────
+function runSearch(query, count, envOverrides) {
   const cliPath = path.join(__dirname, '..', 'dist/cli.js');
-  const env = { ...process.env };
-  if (compact) {
-    env.OUTPUT_STYLE = 'compact';
-  }
+  const env = { ...process.env, ...envOverrides };
   const start = Date.now();
   let rawOutput;
   try {
     rawOutput = execFileSync(
       'node', [cliPath, 'search', query, '--count', String(count), '--json'],
-      { timeout: 30000, encoding: 'utf-8', maxBuffer: 50 * 1024 * 1024, stdio: ['pipe', 'pipe', 'ignore'], env }
+      { timeout: 45000, encoding: 'utf-8', maxBuffer: 50 * 1024 * 1024, stdio: ['pipe', 'pipe', 'pipe'], env }
     );
   } catch (e) {
     return { success: false, error: e.message, duration: Date.now() - start };
@@ -81,102 +106,204 @@ function runSearch(query, count = 10, compact = false) {
 
   const resultJson = parseOutput(rawOutput);
   if (!resultJson) {
-    return { success: false, error: 'no result JSON found', duration, raw: rawOutput.slice(0, 500) };
-  }
-
-  // Extract log lines for per-engine latency
-  const engineLatencies = [];
-  for (const line of rawOutput.split('\n')) {
-    try {
-      const parsed = JSON.parse(line);
-      if (parsed.engine && typeof parsed.latency === 'number') {
-        engineLatencies.push({ engine: parsed.engine, latency: parsed.latency });
-      }
-    } catch {}
+    return { success: false, error: 'parse failed', duration };
   }
 
   const results = resultJson.results || [];
+  if (results.length === 0) {
+    return { success: false, error: 'no results (rate limited?)', duration, enginesUsed: resultJson.engines || [] };
+  }
+
+  const enginesUsed = resultJson.engines || [];
+  const fullJson = JSON.stringify(resultJson);
+  const tokenCount = countTokens(fullJson);
+  const resultsOnlyJson = JSON.stringify(results);
+  
   const confidenceScores = results.map(r => r.confidence).filter(c => c != null);
   const urls = results.map(r => r.url).filter(Boolean);
-
-  // Token savings: compare our compressed JSON output to estimated raw SERP size
-  const compressedChars = JSON.stringify(results).length;
-  const estimatedRawChars = results.reduce((sum, r) => {
-    // Raw search result: title + url + full snippet (~300 chars)
-    return sum + (r.title || '').length + (r.url || '').length + 300;
-  }, 0);
-  const tokenRatio = estimatedRawChars > 0
-    ? ((1 - compressedChars / estimatedRawChars) * 100).toFixed(1)
-    : '0.0';
 
   return {
     success: true,
     duration,
     resultsCount: results.length,
-    enginesUsed: resultJson.engines || [],
-    enginesCount: (resultJson.engines || []).length,
-    engineLatencies,
-    confidenceScores,
+    enginesUsed,
+    enginesCount: enginesUsed.length,
+    responseBytes: Buffer.byteLength(fullJson, 'utf-8'),
+    responseChars: fullJson.length,
+    tokenCount,
     avgConfidence: confidenceScores.length > 0
-      ? (confidenceScores.reduce((a, b) => a + b, 0) / confidenceScores.length).toFixed(2)
-      : '0.00',
-    urls,
+      ? parseFloat((confidenceScores.reduce((a, b) => a + b, 0) / confidenceScores.length).toFixed(2))
+      : 0,
     totalUrls: urls.length,
     uniqueUrls: new Set(urls).size,
-    overlapCount: urls.length - new Set(urls).size,
-    compressedChars,
-    estimatedRawChars,
-    tokenRatio: parseFloat(tokenRatio),
-    rawResponseSize: rawOutput.length,
   };
 }
 
+// ── Run all queries for one scenario ──────────────────────────────────
+function runScenario(label, envOverrides) {
+  const results = [];
+  let successCount = 0, totalEngines = 0, totalTokens = 0, totalDuration = 0, waterfallPhase1 = 0;
+  const confidences = [];
+  const timings = [];
+
+  console.log(`\n=== ${label} ===`);
+  console.log(`    Config: ${Object.entries(envOverrides).map(([k,v]) => `${k}=${v}`).join(', ') || 'default'}`);
+
+  for (const [i, q] of queries.entries()) {
+    const r = runSearch(q.q, 10, envOverrides);
+    results.push(r);
+    
+    if (r.success) {
+      successCount++;
+      totalEngines += r.enginesCount;
+      totalTokens += r.tokenCount;
+      totalDuration += r.duration;
+      timings.push(r.duration);
+      if (r.avgConfidence > 0) confidences.push(r.avgConfidence);
+      if (r.enginesCount <= 2) waterfallPhase1++;
+      
+      const pct = ((i + 1) / queries.length * 100).toFixed(0);
+      console.log(`  [${i + 1}/${queries.length}] ${pct}% ✓ ${r.enginesCount}eng ${r.tokenCount}tk ${r.duration}ms`);
+    } else {
+      console.log(`  [${i + 1}/${queries.length}] ✗ ${r.error}`);
+    }
+  }
+
+  // Latency percentiles
+  timings.sort((a, b) => a - b);
+  const p50 = timings.length > 0 ? timings[Math.floor(timings.length * 0.5)] : 0;
+  const p95 = timings.length > 0 ? timings[Math.floor(timings.length * 0.95)] : 0;
+
+  return {
+    label,
+    total: queries.length,
+    successCount,
+    successRate: ((successCount / queries.length) * 100).toFixed(1) + '%',
+    avgEngines: successCount > 0 ? (totalEngines / successCount).toFixed(1) : '0',
+    waterfallPhase1Rate: successCount > 0 ? ((waterfallPhase1 / successCount) * 100).toFixed(0) + '%' : '0%',
+    avgTokens: successCount > 0 ? Math.round(totalTokens / successCount) : 0,
+    totalTokens,
+    avgDuration: successCount > 0 ? Math.round(totalDuration / successCount) + 'ms' : '0ms',
+    p50: p50 + 'ms',
+    p95: p95 + 'ms',
+    avgConfidence: confidences.length > 0
+      ? (confidences.reduce((a, b) => a + b, 0) / confidences.length).toFixed(2)
+      : '0.00',
+    results,
+  };
+}
+
+// ── Main ──────────────────────────────────────────────────────────────
 console.log('=== Agent Search MCP Benchmark ===');
 console.log(`Date: ${new Date().toISOString().split('T')[0]}`);
-console.log(`Queries: ${queries.length}`);
-console.log('');
+console.log(`Queries: ${queries.length} (${queries.filter(q => q.lang === 'en').length} EN + ${queries.filter(q => q.lang === 'zh').length} ZH)`);
 
-// ── Run comparison: normal vs compact ──────────────────────────────────
-console.log('=== Normal mode ===');
-let normalTotal = 0, normalOk = 0;
-for (const [i, q] of queries.entries()) {
-  process.stdout.write(`  [${i + 1}/${queries.length}] "${q.q.slice(0, 40)}..." `);
-  const r = runSearch(q.q, 10, false);
-  if (r.success) { normalOk++; normalTotal += r.rawResponseSize || 0; console.log(`✓ ${r.rawResponseSize}B`); }
-  else { console.log(`✗ ${r.error}`); }
-}
+// 3 scenarios
+const normal = runScenario('Normal (waterfall, default)', {});
+const compact = runScenario('Compact (progressive disclosure)', {
+  OUTPUT_STYLE: 'compact',
+  MAX_FULL_RESULTS: '3',
+});
+const compactAggressive = runScenario('Compact Aggressive (short snippets)', {
+  OUTPUT_STYLE: 'compact',
+  MAX_FULL_RESULTS: '3',
+  SNIPPET_LENGTH: '120',
+});
 
-console.log('');
-console.log('=== Compact mode ===');
-let compactTotal = 0, compactOk = 0;
-for (const [i, q] of queries.entries()) {
-  process.stdout.write(`  [${i + 1}/${queries.length}] "${q.q.slice(0, 40)}..." `);
-  const r = runSearch(q.q, 10, true);
-  if (r.success) { compactOk++; compactTotal += r.rawResponseSize || 0; console.log(`✓ ${r.rawResponseSize}B`); }
-  else { console.log(`✗ ${r.error}`); }
-}
+// ── Comparison ────────────────────────────────────────────────────────
+console.log('\n');
+console.log('═══════════════════════════════════════════════════════');
+console.log('               COMPARISON SUMMARY');
+console.log('═══════════════════════════════════════════════════════\n');
 
-console.log('');
-console.log('=== Comparison ===');
-const avgNormal = normalOk > 0 ? (normalTotal / normalOk).toFixed(0) : '0';
-const avgCompact = compactOk > 0 ? (compactTotal / compactOk).toFixed(0) : '0';
-const savings = normalTotal > 0 ? ((1 - compactTotal / normalTotal) * 100).toFixed(1) : '0.0';
-console.log(`Normal avg response:  ${avgNormal} bytes`);
-console.log(`Compact avg response: ${avgCompact} bytes`);
-console.log(`Total savings:        ${savings}% (${normalTotal} → ${compactTotal} bytes over ${normalOk} queries)`);
+const scenarios = [normal, compact, compactAggressive];
+const h = (s, w) => String(s).padStart(w);
 
-// Save report
-const report = {
-  date: new Date().toISOString().split('T')[0],
-  queries: queries.length,
-  normalModeAvgBytes: parseInt(avgNormal),
-  compactModeAvgBytes: parseInt(avgCompact),
-  totalBytesNormal: normalTotal,
-  totalBytesCompact: compactTotal,
-  savingsPercent: parseFloat(savings),
-  queriesCompleted: normalOk,
+console.log(`${'Metric'.padEnd(28)} ${h('Normal', 14)} ${h('Compact', 14)} ${h('Compact+', 14)}`);
+console.log('─'.repeat(72));
+
+const printRow = (label, getVal) => {
+  const vals = scenarios.map(s => getVal(s));
+  console.log(`${label.padEnd(28)} ${h(vals[0], 14)} ${h(vals[1], 14)} ${h(vals[2], 14)}`);
 };
 
-const reportPath = path.join(REPORTS_DIR, `${report.date}-comparison.json`);
-fs.writeFileSync(reportPath, JSON.stringify(report, null, 2));
-console.log(`\nComparison report saved: ${reportPath}`);
+printRow('Success rate', s => s.successRate);
+printRow('Avg engines/query', s => s.avgEngines);
+printRow('Waterfall phase 1', s => s.waterfallPhase1Rate);
+printRow('Avg tokens', s => String(s.avgTokens));
+printRow('Avg latency', s => s.avgDuration);
+printRow('P50 latency', s => s.p50);
+printRow('P95 latency', s => s.p95);
+printRow('Avg confidence', s => s.avgConfidence);
+
+const normalTokens = normal.avgTokens;
+const compactSavings = normalTokens > 0 ? ((1 - compact.avgTokens / normalTokens) * 100).toFixed(1) : '0.0';
+const aggressiveSavings = normalTokens > 0 ? ((1 - compactAggressive.avgTokens / normalTokens) * 100).toFixed(1) : '0.0';
+
+console.log('');
+console.log(`Token savings vs Normal (${tokenCounter}):`);
+console.log(`  Compact:            ${compactSavings}% (${normalTokens} → ${compact.avgTokens} tokens)`);
+console.log(`  Compact Aggressive: ${aggressiveSavings}% (${normalTokens} → ${compactAggressive.avgTokens} tokens)`);
+
+const waterfallSavings = normal.avgEngines > 0 ? ((1 - parseFloat(normal.avgEngines) / 8) * 100).toFixed(0) : '0';
+console.log(`\nWaterfall engine savings: ${waterfallSavings}% (${normal.avgEngines}/8 engines per query)`);
+
+// ── Save ──────────────────────────────────────────────────────────────
+const date = new Date().toISOString().split('T')[0];
+
+const jsonReport = {
+  date, queries: queries.length, tokenCounter,
+  scenarios: {}
+};
+for (const s of scenarios) {
+  jsonReport.scenarios[s.label] = {
+    successRate: s.successRate, avgEngines: s.avgEngines,
+    waterfallPhase1Rate: s.waterfallPhase1Rate, avgTokens: s.avgTokens,
+    avgDuration: s.avgDuration, p50: s.p50, p95: s.p95, avgConfidence: s.avgConfidence,
+  };
+}
+jsonReport.compactTokenSavings = compactSavings + '%';
+jsonReport.compactAggressiveTokenSavings = aggressiveSavings + '%';
+jsonReport.waterfallEngineSavings = waterfallSavings + '%';
+
+fs.writeFileSync(path.join(REPORTS_DIR, `${date}.json`), JSON.stringify(jsonReport, null, 2));
+
+// Markdown
+const md = `# Benchmark Report — ${date}
+
+Token counter: **${tokenCounter}**
+
+## Results (${queries.length} queries: ${queries.filter(q => q.lang === 'en').length} EN + ${queries.filter(q => q.lang === 'zh').length} ZH)
+
+| Metric | Normal | Compact | Compact Aggressive |
+|--------|--------|---------|-------------------|
+| Success rate | ${normal.successRate} | ${compact.successRate} | ${compactAggressive.successRate} |
+| Avg engines/query | ${normal.avgEngines} | ${compact.avgEngines} | ${compactAggressive.avgEngines} |
+| Waterfall phase 1 | ${normal.waterfallPhase1Rate} | ${compact.waterfallPhase1Rate} | ${compactAggressive.waterfallPhase1Rate} |
+| Avg tokens | ${normal.avgTokens} | ${compact.avgTokens} | ${compactAggressive.avgTokens} |
+| Avg latency | ${normal.avgDuration} | ${compact.avgDuration} | ${compactAggressive.avgDuration} |
+| P50 latency | ${normal.p50} | ${compact.p50} | ${compactAggressive.p50} |
+| P95 latency | ${normal.p95} | ${compact.p95} | ${compactAggressive.p95} |
+| Avg confidence | ${normal.avgConfidence} | ${compact.avgConfidence} | ${compactAggressive.avgConfidence} |
+
+## Token Savings
+
+| Comparison | Savings |
+|------------|---------|
+| Compact vs Normal | **${compactSavings}%** |
+| Compact Aggressive vs Normal | **${aggressiveSavings}%** |
+| Waterfall vs naive 8-engine | **${waterfallSavings}% fewer calls** |
+
+## Configuration
+
+| Scenario | OUTPUT_STYLE | MAX_FULL_RESULTS | SNIPPET_LENGTH |
+|----------|-------------|-----------------|----------------|
+| Normal | (default) | — | 200 |
+| Compact | compact | 3 | 200 |
+| Compact Aggressive | compact | 3 | 120 |
+`;
+
+fs.writeFileSync(path.join(REPORTS_DIR, `${date}.md`), md);
+
+console.log(`\nReports: reports/${date}.json, reports/${date}.md`);
+console.log('✓ Done.');

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "agent-search-mcp",
   "mcpName": "io.github.lennney/agent-search-mcp",
   "version": "3.1.3",
-  "description": "Zero-config MCP web search for AI agents: 11 engines (8 free, no API key), Chinese search, waterfall multi-source verification, content extraction, news search & Streamable HTTP. Works with Claude Code, Cursor, Codex.",
+  "description": "Zero-config MCP web search for AI agents: 12 engines (8 free, no API key), Chinese search, waterfall multi-source verification, content extraction, news search & Streamable HTTP. Works with Claude Code, Cursor, Codex.",
   "type": "module",
   "main": "./dist/index.js",
   "bin": {
@@ -27,7 +27,7 @@
   "bugs": {
     "url": "https://github.com/lennney/agent-search-mcp/issues"
   },
-  "license": "MIT",
+  "license": "Apache-2.0",
   "keywords": [
     "mcp",
     "mcp-server",
@@ -59,7 +59,10 @@
     "content-extraction",
     "open-source",
     "self-hosted",
-    "chinese-search"
+    "chinese-search",
+    "youcom",
+    "semantic-dedup",
+    "semantic-rerank"
   ],
   "scripts": {
     "build": "tsc && mkdir -p dist/aggregation && cp src/aggregation/semantic_bridge.py dist/aggregation/semantic_bridge.py && node -e \"require('fs').chmodSync('dist/index.js', '755')\"",


### PR DESCRIPTION
## Summary

Unifies README messaging across EN/ZH, rewrites benchmarks with real token data, and fixes multiple inconsistencies.

## Changes

### README overhaul (EN + ZH)
- **Engine count: 11 → 12** everywhere (frontmatter, snapshot, package.json) — You.com was missing
- **Added You.com** to engines table
- **License: MIT → Apache-2.0** (matching LICENSE file)
- **Added competitor comparison table** with real data (Tavily $30/mo, Exa $50/mo, Brave $15/mo vs our $0)
- **Removed outdated project stats** (test counts, source lines, dep counts — competitors don't do this)
- **Removed defensive competitor comparison walls** — replaced with concise data-backed selling points
- **Mirror EN/ZH structure** for consistency

### Benchmark rewrite
- New bench runner: **3 scenarios** (Normal / Compact / Compact Aggressive)
- **Optional tiktoken** support for precise token counting (falls back to char estimation)
- Fixed parsing for mixed NDJSON + multi-line JSON CLI output
- Added latency P50/P95, per-query token counts, waterfall efficiency tracking
- Auto-generates JSON + MD reports

### Fresh bench data (30 queries: 15 EN + 15 ZH)

| Metric | Normal | Compact | Compact+ |
|--------|--------|---------|----------|
| Success rate | 100% | 100% | 96.7% |
| Avg tokens | 1582 | 1128 | 1020 |
| Token savings | — | **28.7%** | **35.5%** |
| Waterfall | 100% phase 1 | 100% | 100% |

Waterfall saves **75% engine calls** (2 vs 8 in naive multi-search).

### Package.json
- `description`: 11 → 12 engines
- `license`: MIT → Apache-2.0
- `keywords`: added `youcom`, `semantic-dedup`, `semantic-rerank`

## Files changed
- `README.md` — restructured, data-backed selling points
- `README_zh.md` — mirrored EN structure, all numbers aligned
- `benchmarks/README.md` — updated with latest results + historical table
- `benchmarks/run.cjs` — rewritten with 3 scenarios, tiktoken support
- `benchmarks/reports/2026-07-24.json` — new bench data
- `benchmarks/reports/2026-07-24.md` — new bench report
- `package.json` — license, description, keywords
