### PR TITLE
chore: release v3.2.0-beta.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,76 +11,59 @@ tags:
 
 ## Unreleased
 
-### Features
+## v3.2.0-beta.0 (2026-07-27)
 
-- Unified all 12 search adapters across MCP, advanced search, CLI, and waterfall routing.
-- Split result signals into `relevance`, normalized `confidence`, and independent `source_count`; retained `score` as a deprecated compatibility alias and mapped legacy `MIN_CONFIDENCE=2/3` values to source count.
-- Added a capture/replay benchmark with production execution telemetry, frozen fixtures, locked `gpt-tokenizer`, and a CI regression gate. Historical 30-query measurements remain published with their environment scope.
-- Secured HTTP MCP mode with required Bearer authentication and browser Origin allowlisting. Unauthenticated mode now requires explicit `HTTP_ALLOW_UNAUTHENTICATED=true`.
+> **Headline: Beta release — Progressive disclosure + semantic dedup/rerank. Server testing.**
 
-### Documentation
+This is a **beta** release (`npm tag: beta`) for server-side validation before stable v3.2.0. Semantic features are opt-in (OFF by default). See below for full changelog.
 
-- Restored the historical 28.7% / 35.5% token and 75% engine-call measurements in README and promotion drafts with explicit query-set and environment boundaries.
-
-## v3.3.0 (2026-07-24)
-
-> **Headline: Semantic dedup + rerank via Model2Vec. <10ms latency. Optional, opt-in.**
-
-### 🆕 Features
+### 🆕 Semantic Layer (P2)
 
 - **Semantic dedup** (`SEMANTIC_DEDUP=true`): Removes semantically duplicate results across engines using cosine similarity on Model2Vec embeddings. Keeps higher-confidence items. Adds `removedCount` feedback.
 - **Semantic rerank** (`SEMANTIC_RERANK=true`): Reorders results by semantic similarity to the query. Returns top-K most relevant results.
 - **Model2Vec bridge**: Persistent Python child process (`src/aggregation/semantic_bridge.py`) running `minishlab/M2V_base_output` (256-dim, 7.2MB model). Embedding speed ~35µs/text, dedup + rerank <5ms total latency.
-- **Zero dependency by default**: Semantic features are OFF by default. No Python/model2vec required unless explicitly enabled.
-- **Graceful degradation**: If the Python bridge is unavailable (no model2vec installed, process crash, etc.), results pass through unchanged — no broken searches.
+- **Zero dependency by default**: Semantic features OFF by default. No Python/model2vec required unless explicitly enabled.
+- **Graceful degradation**: If Python bridge is unavailable, results pass through unchanged — no broken searches.
+
+### 🆕 Progressive Disclosure
+
+- **Progressive disclosure**: `MAX_FULL_RESULTS` (default 3) — first N results full, remaining compacted. Agent can expand via `free_extract`. Saves ~36-58% tokens in compact mode.
+- **Confidence filtering**: `MIN_CONFIDENCE` (default 0=off) — filter low-confidence results. Adds `filtered_count` to meta.
+- **Traceable**: `compacted:true` marker, `compacted_count`, `filtered_count` in meta.
+- **New env vars**: `MAX_FULL_RESULTS` (1-20), `MIN_CONFIDENCE` (0.0-3.0), `SEMANTIC_DEDUP`, `SEMANTIC_RERANK`, `DEDUP_THRESHOLD`, `RERANK_TOP_K`
+
+### 🆕 Platform & Infrastructure
+
+- **Unified 12 search adapters** across MCP, advanced search, CLI, and waterfall routing.
+- **Split result signals** into `relevance`, normalized `confidence`, and independent `source_count`; retained `score` as deprecated compatibility alias.
+- **Capture/replay benchmark** with production execution telemetry, frozen fixtures, locked `gpt-tokenizer`, and a CI regression gate.
+- **Secured HTTP MCP** with required Bearer authentication and browser Origin allowlisting. `HTTP_ALLOW_UNAUTHENTICATED=true` to disable.
+- **Closed CSDN SSRF path**: `fetch_csdn_article` accepts only HTTPS `blog.csdn.net` URLs.
+- **Cross-platform build**: Node.js build helper replaces POSIX-only mkdir/cp; `npm run build` works on Windows.
+- **CI coverage**: Node.js 18/20/22 across Linux + Windows.
+- **Runtime metadata**: MCP init, HTTP health, capabilities now report v3.2.0-beta.0 consistently.
 
 ### 🔧 Fixes
 
-- **Restored zero-Python DDG fallback**: The search orchestrator no longer rejects DuckDuckGo before its Node.js HTML fallback can run.
-- **Protected stdio JSON-RPC**: Circuit-breaker transitions now use the stderr logger instead of writing to stdout.
-- **Closed CSDN SSRF path**: `fetch_csdn_article` now accepts only HTTPS `blog.csdn.net` URLs and rejects redirects.
-- **Cross-platform build**: Replaced POSIX-only `mkdir`/`cp` commands with a Node.js build helper; `npm run build` now works on Windows.
-- **CI coverage**: Restored Node.js 18/20/22 runtime coverage, added a Node.js 22 quality gate, disabled matrix fail-fast, and added a Windows build job.
-- **Node.js 18 compatibility**: Pinned Cheerio to its Node 18-compatible release and close idle HTTP connections during shutdown.
-- **Lint compatibility**: Pinned TypeScript to the supported 6.x API until `typescript-eslint` supports TypeScript 7.
-- **Runtime metadata**: MCP initialization, HTTP health, and capabilities now report v3.1.3 / Apache-2.0 consistently with the published package.
+- Restored zero-Python DDG fallback (orchestrator no longer rejects DDG before HTML fallback runs).
+- Protected stdio JSON-RPC (circuit-breaker uses stderr logger, not stdout).
+- Node.js 18 compatibility: pinned Cheerio to compatible release.
+- Lint compatibility: pinned TypeScript to 6.x until typescript-eslint supports TS 7.
 
 ### 📚 Documentation
 
-- Replaced volatile competitor pricing claims with a capability-based comparison linked to official repositories.
-- Marked historical benchmark percentages as exploratory until engine-call telemetry and frozen fixtures are implemented.
-- Added a reusable English/Chinese promotion kit and rewrote the Juejin draft around verified capabilities.
-
-### 🔧 Env vars
-
-| Variable | Default | Description |
-|----------|---------|-------------|
-| `SEMANTIC_DEDUP` | `false` | Enable semantic dedup |
-| `DEDUP_THRESHOLD` | `0.85` | Cosine similarity threshold |
-| `DEDUP_MODEL` | `minishlab/M2V_base_output` | Model2Vec model for dedup |
-| `SEMANTIC_RERANK` | `false` | Enable semantic rerank |
-| `RERANK_TOP_K` | `5` | Results to keep after rerank |
-| `RERANK_MODEL` | `minishlab/M2V_base_output` | Model2Vec model for rerank |
+- Replaced volatile competitor pricing claims with capability-based comparison.
+- Added promotion kit (EN/ZH) and rewrote Juejin draft.
+- Restored historical 28.7%/35.5% token savings and 75% engine-call measurements with explicit environment boundaries.
 
 ### 📊 Stats
 
-- **Tests**: 498 passing
+- **Tests**: 498 passing (was 448 at v3.1.3)
 - **Files**: 43 test files
+- **Engines**: 11 (8 free, 3 paid)
+- **Dependencies**: 5 production (unchanged)
 
-## v3.2.0 (2026-07-24)
-
-> **Headline: Progressive disclosure + confidence filtering. 36-58% fewer tokens in compact mode.**
-
-### 🆕 Features
-
-- **Progressive disclosure**: `MAX_FULL_RESULTS` (default 3) — first N results full (title+snippet+confidence), remaining compacted (title+url+`compacted:true`). Agent can expand via `free_extract`. Saves ~36% tokens.
-- **Confidence filtering**: `MIN_CONFIDENCE` (default 0=off) — filter out low-confidence results before formatting. Adds `filtered_count` to meta.
-- **Traceable**: `compacted:true` marker, `compacted_count`, `filtered_count` in meta — Agent knows what's truncated and can recover.
-- **New env vars**: `MAX_FULL_RESULTS` (1-20), `MIN_CONFIDENCE` (0.0-3.0)
-
-### 🔧 Fixes
-
-- `compact` mode now includes `compacted_count` and `filtered_count` in meta when respective options are active
+---
 
 ## v3.1.2 (2026-07-22)
 

--- a/docs/geo/DISTRIBUTION_STATUS.md
+++ b/docs/geo/DISTRIBUTION_STATUS.md
@@ -1,7 +1,7 @@
 # 分发渠道状态追踪 — Agent Search MCP
 
-> 最后更新: 2026-07-25
-> npm: v3.1.3 | GitHub Stars: 10 | 近 30 天下载: 1,952
+> 最后更新: 2026-07-27
+> npm: v3.1.3 (latest) / v3.2.0-beta.0 (beta) | GitHub Stars: 20 | 月下载: 1,840
 
 ---
 
@@ -9,10 +9,12 @@
 
 | 指标 | 数值 |
 |------|------|
-| npm 版本 | v3.1.3 |
-| npm 近 30 天下载 | 1,952 |
-| npm 近 7 天下载 | 1,049 |
-| GitHub Stars | 10 |
+| npm 最新版 | v3.1.3 |
+| npm beta 版 | v3.2.0-beta.0 ✅ 刚发 |
+| npm 月下载 | 1,840 |
+| npm 周下载 | 900 |
+| npm 日下载 | 62 |
+| GitHub Stars | 20 ⭐ |
 | GitHub Topics | 20 |
 | npm keywords | 31 |
 
@@ -24,23 +26,22 @@
 
 | 渠道 | 链接 / ID | 备注 |
 |------|----------|------|
-| **npm** | `agent-search-mcp` v3.1.3 | `npx agent-search-mcp` 可用 |
+| **npm** | `agent-search-mcp` | latest v3.1.3 / beta v3.2.0-beta.0 |
 | **GitHub** | `lennney/agent-search-mcp` | 20 topics, badges, CI, Releases |
-| **Glama** | [glama.ai/mcp/servers/lennney/agent-search-mcp](https://glama.ai/mcp/servers/lennney/agent-search-mcp) | 绿色评分，**未 Claim** |
-| **mcp.so** | [mcp.so/servers/agent-search-dc1371](https://mcp.so/servers/agent-search-dc1371) | 已上线，READM 已优化等待重新扫描 |
-| **Official MCP Registry** | `io.github.lennney/agent-search-mcp` | v3.1.3 已发布 |
-| **mcprepository.com** | 自动收录 | — |
-| **mcpmarket.com** | 自动收录 | — |
-| **punkpeye/awesome-mcp-servers** | [PR #10383](https://github.com/punkpeye/awesome-mcp-servers/pull/10383) ✅ **已合并** | 条目已在主 README 中 |
-| **patriksimek/awesome-mcp-servers-2** | [PR #21](https://github.com/patriksimek/awesome-mcp-servers-2/pull/21) | ✅ |
-| **重复 PR #10640** | [已关闭](https://github.com/punkpeye/awesome-mcp-servers/pull/10640) | 已注明由 #10383 收录 |
+| **Glama** | [glama.ai/mcp/servers/lennney/agent-search-mcp](https://glama.ai/mcp/servers/lennney/agent-search-mcp) | ✅ **已 Claim**，维护/质量/许可全 A |
+| **Official MCP Registry** | `io.github.lennney/agent-search-mcp` | v3.1.3 已发布，状态 active |
+| **mcp.so** | [mcp.so/servers/agent-search-dc1371](https://mcp.so/servers/agent-search-dc1371) | 已上线（slug 非标准） |
+| **awesome-mcp-servers (punkpeye)** | [PR #10383](https://github.com/punkpeye/awesome-mcp-servers/pull/10383) | ✅ **已合并** (2026-07-22) |
+| **PulseMCP** | pulsemcp.com | 搜索结果有返回，待确认索引 |
 
-### ⏳ 等待中
+### ⏳ 待确认 / 待收录
 
 | 渠道 | 状态 | 备注 |
 |------|------|------|
-| **mcp.directory** | 你已提交，待收录 | 未在搜索中找到 (404) |
-| **mcpservers.org** | 你已提交，待收录 | 未在搜索中找到 (404) |
+| **mcp.directory** | ❌ 404 | 之前说已提交但未收录，仍未索引 |
+| **mcpservers.org** | ❌ 404 | 同上 |
+| **mcprepository.com** | ❌ 404 | 自动发现未生效 |
+| **mcpmarket.com** | 403 | 可能需要登录或自动发现未完成 |
 
 ### ❌ 未提交
 
@@ -48,20 +49,20 @@
 |------|------|------|
 | **LobeHub** | 需 `lhm login` + `lhm github connect` 后提交 | 5min |
 | **Smithery** | 有 API key 即可 curl 提交 | 5min |
-| **PulseMCP** | 发邮件到 `hello@pulsemcp.com` 或提交表单 | 2min |
 | **FastMCP** | 打开 https://fastmcp.com/submit | 2min |
 | **awesome-remote-mcp-servers** | GitHub PR 加一行 | 5min |
-| **Rodert/awesome-mcp** | 已达到 10 Stars 门槛，重新检查提交规范 | 5min |
+| **Rodert/awesome-mcp** | [PR #19](https://github.com/Rodert/awesome-mcp/pull/19) | ⏳ OPEN，待合并 |
+| **patriksimek/awesome-mcp-servers-2** | PR 到 README（之前 PR #21 是 mcp-slim-guard，非本项目） | 5min |
 
 ### 📝 内容营销待发布
 
 | 平台 | 文件 | 状态 |
 |------|------|:----:|
-| **掘金** (ZH) | `docs/geo/juejin-agent-search-mcp.md` | ✅ 已按现状重写 |
-| **dev.to** (EN) | `docs/geo/PROMOTION_KIT.md` | ✅ 大纲就绪 |
-| **V2EX** (ZH) | `docs/geo/PROMOTION_KIT.md` | ✅ 短文就绪 |
-| **Reddit r/mcp** (EN) | `docs/geo/PROMOTION_KIT.md` | ✅ 短文就绪 |
-| **MCP Discord #showcase** | `docs/geo/PROMOTION_KIT.md` | ✅ 短文就绪 |
+| **掘金** (ZH) | `docs/geo/juejin-agent-search-mcp.md` | 📝 草稿就绪 |
+| **dev.to** (EN) | 未写 | ❌ |
+| **V2EX** (ZH) | 未写 | ❌ |
+| **Reddit r/mcp** (EN) | 未写 | ❌ |
+| **MCP Discord #showcase** | 未写 | ❌ |
 
 ### 🚫 跳过
 
@@ -74,17 +75,26 @@
 ## 行动清单 (按优先级)
 
 ```
-P0 ─── 合并产品加固改动，等待 Linux/Windows CI 通过
-    ├── Claim Glama → 打开 glama.ai 点 Claim
-    ├── PulseMCP 提交
-    └── FastMCP 提交
+P0 ─── FastMCP 提交（2min）
+    ├── 等 Rodert PR #19 合并
+    └── 关掉旧 dist 记录（v3.1.3 → 标记 beta 存在）
 
-P1 ─── 发掘金文章（已按真实能力重写）
-    ├── 发 dev.to / V2EX / Reddit 短文
+P1 ─── 发掘金文章（草稿已就绪）
+    ├── 写 dev.to / V2EX 草稿
     ├── LobeHub 登录后提交
-    └── Smithery 提交
+    └── Smithery 提交（curl）
 
 P2 ─── Docker Hub 推送（Mac）
     ├── awesome-remote-mcp-servers PR
-    └── MCP Discord 发帖
+    ├── MCP Discord 发帖
+    └── patriksimek/awesome-mcp-servers-2 PR
 ```
+
+---
+
+## 版本发布历史
+
+| 版本 | 日期 | 渠道 | 备注 |
+|------|------|------|------|
+| v3.1.3 | 已发布 | npm (latest) | 当前 stable |
+| v3.2.0-beta.0 | 2026-07-27 | npm (beta) | P2 语义层，服务器测试中 |

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "agent-search-mcp",
   "mcpName": "io.github.lennney/agent-search-mcp",
-  "version": "3.1.3",
+  "version": "3.2.0-beta.0",
   "description": "Zero-config MCP web search for AI agents: 12 adapters (8 zero-key), native Chinese search, multi-source aggregation, extraction, news & Streamable HTTP. Works with Claude Code, Cursor, Codex.",
   "type": "module",
   "main": "./dist/index.js",


### PR DESCRIPTION
## Summary

Publish **agent-search-mcp@3.2.0-beta.0** on npm (tag: `beta`).

### Changes
- **package.json**: v3.1.3 → v3.2.0-beta.0
- **CHANGELOG.md**: Merged Unreleased/v3.2.0/v3.3.0 entries into one beta release entry
- **DISTRIBUTION_STATUS.md**: Updated channel data (20⭐, Glama claimed, Rodert PR#19 open, beta listed)
- **New cron job**: `search-quality-monitor.sh` — daily 10AM watchdog, silent on success, alerts on degradation

### Why beta
Semantic layer (P2) needs server-side validation before stable 3.2.0. The `beta` npm tag leaves `latest` at 3.1.3 so existing users aren't affected.