### PR TITLE
feat: add SerpBase (Google) search engine via REST API

### DIFF
--- a/src/aggregation/dedup.ts
+++ b/src/aggregation/dedup.ts
@@ -20,6 +20,7 @@ export const PROVIDER_FAMILIES: Readonly<Record<string, string>> = {
   tencent_wsa: 'sogou',
   bocha: 'bocha',
   serper: 'google',
+  serpbase: 'google',
 };
 
 export function getProviderFamily(engine: string): string {

--- a/src/engines/index.ts
+++ b/src/engines/index.ts
@@ -19,6 +19,7 @@ export {
 } from './tencent-wsa.js';
 export { searchBocha, bochaProvider } from './bocha.js';
 export { searchSerper, serperProvider } from './serper.js';
+export { searchSerpBase, serpbaseProvider } from './serpbase.js';
 
 interface LocalizedText {
   en: string;
@@ -51,6 +52,7 @@ export const engines: Record<SearchProvider, EngineCapability> = {
   tencent_wsa: { id: 'tencent_wsa', name: 'Tencent Web Search API', isFree: false, languages: ['zh'], credentialEnvironment: 'TENCENT_WSA_API_KEY', strengths: { en: 'Optional official Chinese Web Search', zh: '可选官方中文联网搜索' } },
   bocha: { id: 'bocha', name: 'Bocha Web Search', isFree: false, languages: ['zh', 'en'], credentialEnvironment: 'BOCHA_API_KEY', strengths: { en: 'Optional Chinese-first AI Search', zh: '可选中文优先 AI 搜索' } },
   serper: { id: 'serper', name: 'Serper Google Search', isFree: false, languages: ['en', 'zh', 'auto'], credentialEnvironment: 'SERPER_API_KEY', strengths: { en: 'Optional Google SERP Search', zh: '可选 Google SERP 搜索' } },
+  serpbase: { id: 'serpbase', name: 'SerpBase Google Search', isFree: false, languages: ['en', 'zh', 'auto'], credentialEnvironment: 'SERPBASE_API_KEY', strengths: { en: 'Optional Google Search (API, no scraping)', zh: '可选 Google 搜索（API，无需爬虫）' } },
 };
 
 /** Free engines that always work without API keys */

--- a/src/engines/serpbase.ts
+++ b/src/engines/serpbase.ts
@@ -1,0 +1,111 @@
+import type {
+  EngineSearchOptions,
+  SearchProviderInfo,
+  SearchResult,
+} from '../types.js';
+import { EngineAdapterError } from './engine-error.js';
+import {
+  asJsonObject,
+  fetchSearchJson,
+  isWebUrl,
+  readString,
+} from './json-search-api.js';
+
+export const serpbaseProvider: SearchProviderInfo = {
+  id: 'serpbase',
+  name: 'SerpBase Google Search',
+  isFree: false,
+  languages: ['en', 'zh', 'auto'],
+};
+
+function parseSerpBaseResult(value: unknown): SearchResult | null {
+  const item = asJsonObject(value);
+  if (!item) return null;
+  const title = readString(item.title);
+  const url = readString(item.link);
+  if (!title || !isWebUrl(url)) return null;
+
+  return {
+    title,
+    url,
+    snippet: readString(item.snippet),
+    source: 'serpbase',
+    engines: ['serpbase'],
+  };
+}
+
+function parseSerpBaseResponse(value: unknown, count: number): SearchResult[] {
+  const root = asJsonObject(value);
+  if (!root) {
+    throw new EngineAdapterError(
+      'parse_error',
+      'SerpBase returned an invalid JSON payload',
+      {
+        retryable: false,
+        suggestion: 'Use another provider while the response schema is checked',
+      },
+    );
+  }
+  if (readString(root.error)) {
+    throw new EngineAdapterError(
+      'upstream_4xx',
+      'SerpBase rejected the search request',
+      {
+        retryable: false,
+        suggestion: 'Check the SerpBase API key and account access',
+      },
+    );
+  }
+
+  const organic = root.organic_results;
+  if (organic === undefined || organic === null) return [];
+  if (!Array.isArray(organic)) {
+    throw new EngineAdapterError(
+      'parse_error',
+      'SerpBase returned an invalid organic_results payload',
+      {
+        retryable: false,
+        suggestion: 'Use another provider while the response schema is checked',
+      },
+    );
+  }
+
+  return organic
+    .map(parseSerpBaseResult)
+    .filter((result): result is SearchResult => result !== null)
+    .slice(0, count);
+}
+
+export async function searchSerpBase(
+  query: string,
+  count: number = 10,
+  options?: EngineSearchOptions,
+): Promise<SearchResult[]> {
+  const apiKey = process.env.SERPBASE_API_KEY?.trim();
+  if (!apiKey) return [];
+
+  try {
+    const boundedCount = Math.min(Math.max(count, 1), 100);
+    const url = new URL('https://api.serpbase.dev/google/search');
+    url.searchParams.set('q', query);
+    url.searchParams.set('api_key', apiKey);
+    url.searchParams.set('num', String(boundedCount));
+
+    const data = await fetchSearchJson({
+      provider: 'SerpBase',
+      url,
+      init: {
+        method: 'GET',
+        headers: {
+          Accept: 'application/json',
+        },
+      },
+      signal: options?.signal,
+    });
+    return parseSerpBaseResponse(data, boundedCount);
+  } catch (error) {
+    options?.signal?.throwIfAborted();
+    if (options?.throwOnError) throw error;
+    return [];
+  }
+}

--- a/src/tools/free-search.ts
+++ b/src/tools/free-search.ts
@@ -11,6 +11,7 @@ import { searchYouCom } from '../engines/youcom.js';
 import { searchTencentWsa } from '../engines/tencent-wsa.js';
 import { searchBocha } from '../engines/bocha.js';
 import { searchSerper } from '../engines/serper.js';
+import { searchSerpBase } from '../engines/serpbase.js';
 import {
   classifyEngineError,
   EngineAdapterError,
@@ -95,6 +96,7 @@ const ENGINE_WEIGHTS: Record<string, number> = {
   tencent_wsa: 0.9,
   bocha: 0.9,
   serper: 0.9,
+  serpbase: 0.9,
 };
 
 // Infrastructure singletons
@@ -272,6 +274,9 @@ async function searchEngine(
           break;
         case 'serper':
           results = await searchSerper(query, limit, engineOptions);
+          break;
+        case 'serpbase':
+          results = await searchSerpBase(query, limit, engineOptions);
           break;
         default:
           return { engine, status: 'skipped', results: [] };

--- a/src/types.ts
+++ b/src/types.ts
@@ -34,6 +34,7 @@ export const SEARCH_PROVIDERS = [
   'tencent_wsa',
   'bocha',
   'serper',
+  'serpbase',
 ] as const;
 
 export type SearchProvider = typeof SEARCH_PROVIDERS[number];


### PR DESCRIPTION
## Summary
Adds SerpBase as an optional Google search engine via REST API. SerpBase provides clean JSON SERP results without scraping maintenance.

## Background
This project already has multiple Google-backed search providers (Serper, Startpage). SerpBase offers developers a pay-as-you-go Google SERP API alternative with a simple GET interface and 100 free trial queries — no subscription required.

## Changes
- **New**: `src/engines/serpbase.ts` — Google search engine using SerpBase REST API (GET, query params)
- **Updated**: `src/types.ts` — added `serpbase` to SEARCH_PROVIDERS
- **Updated**: `src/engines/index.ts` — registered provider with `SERPBASE_API_KEY` credential env var
- **Updated**: `src/tools/free-search.ts` — added engine weight, import, and switch case
- **Updated**: `src/aggregation/dedup.ts` — mapped to `google` provider family

## Design decisions
| Decision | Rationale |
|----------|-----------|
| GET with query params | SerpBase uses simple URL-based auth; no POST body needed |
| SERPBASE_API_KEY env var | Follows existing convention (SERPER_API_KEY, BRAVE_API_KEY, etc.) |
| Graceful skip when key missing | Matches project philosophy — returns [], other engines continue |
| Mapped to `google` provider family | Ensures correct deduplication with other Google-backed engines |

## Testing
- When `SERPBASE_API_KEY` is set: calls `api.serpbase.dev/google/search`, parses `organic_results`
- When `SERPBASE_API_KEY` is unset: returns `[]` silently, other engines unaffected
- Results follow existing `SearchResult` interface: title, url, snippet, source, engines

## Related
- SerpBase: https://serpbase.dev — 100 free searches, $0.30/1k queries, pay-as-you-go